### PR TITLE
[9.0-remove-headers][FIX]qty to supplier rma

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -434,11 +434,14 @@ class RmaOrderLine(models.Model):
     def _check_move_partner(self):
         for rec in self:
             if (rec.reference_move_id and
-                    rec.reference_move_id.picking_id.partner_id !=
-                    rec.partner_id):
-                raise ValidationError(_(
-                    "RMA customer and originating stock move customer "
-                    "doesn't match."))
+               (rec.reference_move_id.partner_id != rec.partner_id) and
+               (rec.reference_move_id.picking_id.partner_id !=
+                        rec.partner_id)):
+                    raise ValidationError(_(
+                        "RMA customer (%s) and originating stock move customer"
+                        " (%s) doesn't match." % (
+                            rec.reference_move_id.partner_id.name,
+                            rec.partner_id.name)))
 
     @api.multi
     def _remove_other_data_origin(self, exception):


### PR DESCRIPTION
I found out that if I create a picking form scratch the stock move has no partner. There's a constraint that compares the origin move's partner with the partner in the rma line. This fix prevent the constraint to be raised in case of manual picking.