### PR TITLE
[FIX] rma: qty_delivered computed value is not updated properly

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -120,10 +120,7 @@ class RmaOrderLine(models.Model):
     @api.depends('move_ids', 'move_ids.state', 'type')
     def _compute_qty_received(self):
         for rec in self:
-            if rec.supplier_to_customer:
-                qty = rec._get_rma_move_qty('done', direction='out')
-            else:
-                qty = rec._get_rma_move_qty('done', direction='in')
+            qty = rec._get_rma_move_qty('done', direction='in')
             rec.qty_received = qty
 
     @api.multi
@@ -138,10 +135,7 @@ class RmaOrderLine(models.Model):
     @api.depends('move_ids', 'move_ids.state', 'type')
     def _compute_qty_delivered(self):
         for rec in self:
-            if rec.supplier_to_customer:
-                qty = rec._get_rma_move_qty('done', direction='in')
-            else:
-                qty = rec._get_rma_move_qty('done', direction='out')
+            qty = rec._get_rma_move_qty('done', direction='out')
             rec.qty_delivered = qty
 
     @api.model


### PR DESCRIPTION
The computed value qty_delivered was not updated when a deliver was created