### PR TITLE
[12.0] rma_account: fix res.groups and test

### DIFF
--- a/rma_account/tests/test_rma_account.py
+++ b/rma_account/tests/test_rma_account.py
@@ -193,6 +193,7 @@ class TestRmaAccount(common.SingleTransactionCase):
             'description': 'Test refund',
         })
         make_refund.invoice_refund()
+        rma.refund_line_ids.invoice_id.action_invoice_open()
         rma.refund_line_ids.invoice_id.invoice_validate()
         rma._compute_refund_count()
         self.assertEqual(rma.refund_count, 1)

--- a/rma_account/wizards/rma_add_invoice.xml
+++ b/rma_account/wizards/rma_add_invoice.xml
@@ -21,7 +21,7 @@
                         <field name="name"/>
                         <field name="account_id" groups="account.group_account_user"/>
                         <field name="quantity"/>
-                        <field name="uom_id" groups="product.group_uom"/>
+                        <field name="uom_id" groups="uom.group_uom"/>
                         <field name="price_unit"/>
                         <field name="discount" groups="sale.group_discount_per_so_line"/>
                         <field name="price_subtotal"/>
@@ -60,7 +60,7 @@
                         <field name="name"/>
                         <field name="account_id" groups="account.group_account_user"/>
                         <field name="quantity"/>
-                        <field name="uom_id" groups="product.group_uom"/>
+                        <field name="uom_id" groups="uom.group_uom"/>
                         <field name="price_unit"/>
                         <field name="discount" groups="sale.group_discount_per_so_line"/>
                         <field name="price_subtotal"/>

--- a/rma_account/wizards/rma_add_invoice.xml
+++ b/rma_account/wizards/rma_add_invoice.xml
@@ -23,7 +23,7 @@
                         <field name="quantity"/>
                         <field name="uom_id" groups="uom.group_uom"/>
                         <field name="price_unit"/>
-                        <field name="discount" groups="sale.group_discount_per_so_line"/>
+                        <field name="discount" groups="base.group_no_one"/>
                         <field name="price_subtotal"/>
                         <field name="currency_id" invisible="1"/>
                     </tree>
@@ -62,7 +62,7 @@
                         <field name="quantity"/>
                         <field name="uom_id" groups="uom.group_uom"/>
                         <field name="price_unit"/>
-                        <field name="discount" groups="sale.group_discount_per_so_line"/>
+                        <field name="discount" groups="base.group_no_one"/>
                         <field name="price_subtotal"/>
                         <field name="currency_id" invisible="1"/>
                     </tree>

--- a/rma_account/wizards/rma_refund.xml
+++ b/rma_account/wizards/rma_refund.xml
@@ -21,7 +21,7 @@
                         <field name="product"/>
                         <field name="name"/>
                         <field name="product_qty"/>
-                        <field name="uom_id" groups="product.group_uom"/>
+                        <field name="uom_id" groups="uom.group_uom"/>
                         <field name="qty_to_refund" readonly="0"/>
                     </tree>
                 </field>


### PR DESCRIPTION
- As I didn't want to add the dependency on `sale`, I did set `base.group_no_one` on `discount` as it is done in `account` module : https://github.com/odoo/odoo/blob/12.0/addons/account/views/account_invoice_view.xml#L53 

- `uom` is already in the dependency chain.

- Tests were failing because invoice was still in draft before validation