### PR TITLE
[FIX] multicompany security

### DIFF
--- a/rma/README.rst
+++ b/rma/README.rst
@@ -115,6 +115,7 @@ Contributors
 * Lois Rilo <lois.rilo@eficent.com>
 * Bhavesh Odedra <bodedra@opensourceintegrators.com>
 * Akim Juillerat <akim.juillerat@camptocamp.com>
+* Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
 
 Maintainer
 ----------

--- a/rma/__manifest__.py
+++ b/rma/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'RMA (Return Merchandise Authorization)',
-    'version': '12.0.2.0.0',
+    'version': '12.0.2.1.0',
     'license': 'LGPL-3',
     'category': 'RMA',
     'summary': 'Introduces the return merchandise authorization (RMA) process '

--- a/rma/models/rma_operation.py
+++ b/rma/models/rma_operation.py
@@ -75,3 +75,7 @@ class RmaOperation(models.Model):
         comodel_name='rma.order.line', inverse_name='operation_id',
         string='RMA lines',
     )
+    company_id = fields.Many2one(
+        comodel_name='res.company', string='Company', required=True,
+        default=lambda self: self.env.user.company_id
+    )

--- a/rma/security/rma.xml
+++ b/rma/security/rma.xml
@@ -49,6 +49,25 @@
                    eval="[(4, ref('group_rma_customer_user')),
                           (4, ref('group_rma_supplier_user'))]"/>
         </record>
+        
+        <record model="ir.rule" id="rma_order_rule">
+          <field name="name">rma order multi-company</field>
+          <field name="model_id" search="[('model','=','rma.order')]" model="ir.model"/>
+          <field name="global" eval="True"/>
+          <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+        </record>
+        <record model="ir.rule" id="rma_order_line_rule">
+          <field name="name">rma order line multi-company</field>
+          <field name="model_id" search="[('model','=','rma.order.line')]" model="ir.model"/>
+          <field name="global" eval="True"/>
+          <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+        </record>
+        <record model="ir.rule" id="rma_operation_rule">
+          <field name="name">rma operation multi-company</field>
+          <field name="model_id" search="[('model','=','rma.operation')]" model="ir.model"/>
+          <field name="global" eval="True"/>
+          <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+        </record>
 
     </data>
 </odoo>

--- a/rma/views/rma_operation_view.xml
+++ b/rma/views/rma_operation_view.xml
@@ -26,6 +26,7 @@
                         <field name="name"/>
                         <field name="type"/>
                         <field name="active"/>
+                        <field name="company_id" groups="base.group_multi_company"/>
                     </group>
                     <group name="policies"
                            string="Policies">


### PR DESCRIPTION
the rma module had company_id fields on rma.order and rma.order.line but not on rma.operation,
and no global multicompany record rules.

-> we fix this and avoid a mess with people allowed to see an operation in the drop down list
but unable to use it because if points to a warehouse of another company