### PR TITLE
[FIX][12.0] multicompany: wrong company on stock rules

### DIFF
--- a/rma/data/stock_data.xml
+++ b/rma/data/stock_data.xml
@@ -113,6 +113,7 @@
 
     <record id="route_rma_customer" model='stock.location.route'>
         <field name="name">RMA Customer</field>
+        <field name="company_id" eval="0"/>
         <field name="sequence">10</field>
         <field name="sale_selectable" eval="False"/>
         <field name="product_selectable" eval="False"/>
@@ -123,6 +124,7 @@
 
     <record id="route_rma_supplier" model='stock.location.route'>
         <field name="name">RMA Supplier</field>
+        <field name="company_id" eval="0"/>
         <field name="sequence">10</field>
         <field name="sale_selectable" eval="False"/>
         <field name="product_selectable" eval="False"/>
@@ -133,6 +135,7 @@
 
     <record id="route_rma_dropship" model='stock.location.route'>
         <field name="name">RMA Dropship</field>
+        <field name="company_id" eval="0"/>
         <field name="sequence">10</field>
         <field name="sale_selectable" eval="False"/>
         <field name="product_selectable" eval="False"/>

--- a/rma/models/stock_warehouse.py
+++ b/rma/models/stock_warehouse.py
@@ -174,13 +174,13 @@ class StockWarehouse(models.Model):
         self.ensure_one()
         rma_rules = dict()
         customer_loc, supplier_loc = self._get_partner_locations()
-        # TODO: company_id?
         rma_rules['rma_customer_in'] = {
             'name': self._format_rulename(self,
                                           customer_loc,
                                           self.lot_rma_id.name),
             'action': 'pull',
             'warehouse_id': self.id,
+            'company_id': self.company_id.id,
             'location_src_id': customer_loc.id,
             'location_id': self.lot_rma_id.id,
             'procure_method': 'make_to_stock',
@@ -194,6 +194,7 @@ class StockWarehouse(models.Model):
                                           customer_loc.name),
             'action': 'pull',
             'warehouse_id': self.id,
+            'company_id': self.company_id.id,
             'location_src_id': self.lot_rma_id.id,
             'location_id': customer_loc.id,
             'procure_method': 'make_to_stock',
@@ -207,6 +208,7 @@ class StockWarehouse(models.Model):
                                           self.lot_rma_id.name),
             'action': 'pull',
             'warehouse_id': self.id,
+            'company_id': self.company_id.id,
             'location_src_id': supplier_loc.id,
             'location_id': self.lot_rma_id.id,
             'procure_method': 'make_to_stock',
@@ -220,6 +222,7 @@ class StockWarehouse(models.Model):
                                           supplier_loc.name),
             'action': 'pull',
             'warehouse_id': self.id,
+            'company_id': self.company_id.id,
             'location_src_id': self.lot_rma_id.id,
             'location_id': supplier_loc.id,
             'procure_method': 'make_to_stock',


### PR DESCRIPTION
when working with odoobot account, you would get the wrong company_id
on the RMA stock.rules of the warehouse on which you enabled RMA

-> Use the warehouse's company, and not the user's company