### PR TITLE
[12.0] RMA Account: use Unit Price from RMA Order

### DIFF
--- a/rma_account/models/__init__.py
+++ b/rma_account/models/__init__.py
@@ -5,3 +5,4 @@ from . import rma_order
 from . import rma_order_line
 from . import rma_operation
 from . import invoice
+from . import stock_move

--- a/rma_account/models/stock_move.py
+++ b/rma_account/models/stock_move.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2019 Daniel Reis, OpenSource Integrators
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _create_account_move_line(
+            self, credit_account_id, debit_account_id, journal_id):
+        self.ensure_one()
+        rma_price = self.rma_line_id.price_unit
+        if rma_price:
+            self = self.with_context(force_valuation_amount=rma_price)
+        return super(StockMove, self)._create_account_move_line(
+            credit_account_id, debit_account_id, journal_id)


### PR DESCRIPTION
Checking the Accounting entries for the Incoming Shipping, I noticed that the value used was the Product's Cost.
In case of an RMA we want the value to the the Price set on the RMA Order.