### PR TITLE
[12.0][ADD]rma_internal_transfer

### DIFF
--- a/account_move_line_rma_order_line/tests/test_account_move_line_rma_order_line.py
+++ b/account_move_line_rma_order_line/tests/test_account_move_line_rma_order_line.py
@@ -180,8 +180,8 @@ class TestAccountMoveLineRmaOrderLine(common.SavepointCase):
             data = wizard._prepare_rma_line_from_stock_move(move)
             wizard.add_lines()
 
-            for operation in move.product_id.rma_customer_operation_id:
-                operation.in_route_id = False
+            if move.product_id.rma_customer_operation_id:
+                move.product_id.rma_customer_operation_id.in_route_id = False
             move.product_id.categ_id.rma_customer_operation_id = False
             move.product_id.rma_customer_operation_id = False
             wizard._prepare_rma_line_from_stock_move(move)

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -121,8 +121,9 @@ class TestRma(common.SavepointCase):
                     _prepare_rma_line_from_stock_move(move)
                 wizard.add_lines()
 
-                for operation in move.product_id.rma_customer_operation_id:
-                    operation.in_route_id = False
+                if move.product_id.rma_customer_operation_id:
+                    move.product_id.rma_customer_operation_id.in_route_id = \
+                        False
                 move.product_id.categ_id.rma_customer_operation_id = False
                 move.product_id.rma_customer_operation_id = False
                 wizard._prepare_rma_line_from_stock_move(move)
@@ -147,8 +148,9 @@ class TestRma(common.SavepointCase):
                     _prepare_rma_line_from_stock_move(move)
                 wizard.add_lines()
 
-                for operation in move.product_id.rma_customer_operation_id:
-                    operation.in_route_id = False
+                if move.product_id.rma_customer_operation_id:
+                    move.product_id.rma_customer_operation_id.in_route_id = \
+                        False
                 move.product_id.categ_id.rma_supplier_operation_id = False
                 move.product_id.rma_supplier_operation_id = False
                 wizard._prepare_rma_line_from_stock_move(move)
@@ -189,8 +191,8 @@ class TestRma(common.SavepointCase):
         }
         return res
 
-    def test_01_rma_order_line(cls):
-        for line in cls.rma_customer_id.rma_line_ids:
+    def test_01_rma_order_line(self):
+        for line in self.rma_customer_id.rma_line_ids:
             line.with_context({'default_rma_id': line.rma_id.id
                                })._default_warehouse_id()
             line._default_location_id()
@@ -200,409 +202,409 @@ class TestRma(common.SavepointCase):
             line._compute_out_shipment_count()
 
             data = {'reference_move_id': line.reference_move_id.id}
-            new_line = cls.rma_line.new(data)
+            new_line = self.rma_line.new(data)
             new_line._onchange_reference_move_id()
 
             # check assert if call reference_move_id onchange
-            cls.assertEquals(new_line.product_id,
-                             line.reference_move_id.product_id)
-            cls.assertEquals(new_line.product_qty,
-                             line.reference_move_id.product_uom_qty)
-            cls.assertEquals(new_line.location_id.location_id,
-                             line.reference_move_id.location_id)
-            cls.assertEquals(new_line.origin,
-                             line.reference_move_id.picking_id.name)
-            cls.assertEquals(new_line.delivery_address_id,
-                             line.reference_move_id.picking_partner_id)
-            cls.assertEquals(new_line.qty_to_receive,
-                             line.reference_move_id.product_uom_qty)
+            self.assertEquals(new_line.product_id,
+                              line.reference_move_id.product_id)
+            self.assertEquals(new_line.product_qty,
+                              line.reference_move_id.product_uom_qty)
+            self.assertEquals(new_line.location_id.location_id,
+                              line.reference_move_id.location_id)
+            self.assertEquals(new_line.origin,
+                              line.reference_move_id.picking_id.name)
+            self.assertEquals(new_line.delivery_address_id,
+                              line.reference_move_id.picking_partner_id)
+            self.assertEquals(new_line.qty_to_receive,
+                              line.reference_move_id.product_uom_qty)
 
             line.action_rma_to_approve()
             line.action_rma_draft()
             line.action_rma_done()
 
             data = {'product_id': line.product_id.id}
-            new_line = cls.rma_line.new(data)
+            new_line = self.rma_line.new(data)
             new_line._onchange_product_id()
 
             data = {'operation_id': line.operation_id.id}
-            new_line = cls.rma_line.new(data)
+            new_line = self.rma_line.new(data)
             new_line._onchange_operation_id()
 
             # check assert if call operation_id onchange
-            cls.assertEquals(new_line.operation_id.receipt_policy,
-                             line.receipt_policy)
+            self.assertEquals(new_line.operation_id.receipt_policy,
+                              line.receipt_policy)
 
             data = {'customer_to_supplier': line.customer_to_supplier}
-            new_line = cls.rma_line.new(data)
+            new_line = self.rma_line.new(data)
             new_line._onchange_receipt_policy()
 
             data = {'lot_id': line.lot_id.id}
-            new_line = cls.rma_line.new(data)
+            new_line = self.rma_line.new(data)
             new_line._onchange_lot_id()
 
             line.action_view_in_shipments()
             line.action_view_out_shipments()
-            cls.rma_customer_id.action_view_supplier_lines()
-            with cls.assertRaises(ValidationError):
-                line.rma_id.partner_id = cls.partner_id.id
-                cls.rma_customer_id.rma_line_ids[0].\
-                    partner_id = cls.env.ref('base.res_partner_3').id
-        cls.rma_customer_id.action_view_supplier_lines()
+            self.rma_customer_id.action_view_supplier_lines()
+            with self.assertRaises(ValidationError):
+                line.rma_id.partner_id = self.partner_id.id
+                self.rma_customer_id.rma_line_ids[0].\
+                    partner_id = self.env.ref('base.res_partner_3').id
+        self.rma_customer_id.action_view_supplier_lines()
 
-    def test_02_customer_rma(cls):
-        wizard = cls.rma_make_picking.with_context({
-            'active_ids': cls.rma_customer_id.rma_line_ids.ids,
+    def test_02_customer_rma(self):
+        wizard = self.rma_make_picking.with_context({
+            'active_ids': self.rma_customer_id.rma_line_ids.ids,
             'active_model': 'rma.order.line',
             'picking_type': 'incoming',
             'active_id': 1
         }).create({})
         wizard._create_picking()
-        res = cls.rma_customer_id.rma_line_ids.action_view_in_shipments()
-        cls.assertTrue('res_id' in res,
-                       "Incorrect number of pickings created")
-        picking = cls.env['stock.picking'].browse(res['res_id'])
-        cls.assertEquals(len(picking), 1,
-                         "Incorrect number of pickings created")
+        res = self.rma_customer_id.rma_line_ids.action_view_in_shipments()
+        self.assertTrue('res_id' in res,
+                        "Incorrect number of pickings created")
+        picking = self.env['stock.picking'].browse(res['res_id'])
+        self.assertEquals(len(picking), 1,
+                          "Incorrect number of pickings created")
         moves = picking.move_lines
-        cls.assertEquals(len(moves), 3,
-                         "Incorrect number of moves created")
-        for line in cls.rma_customer_id.rma_line_ids:
+        self.assertEquals(len(moves), 3,
+                          "Incorrect number of moves created")
+        for line in self.rma_customer_id.rma_line_ids:
             # common qtys for all products
-            cls.assertEquals(line.qty_received, 0,
-                             "Wrong qty received")
-            cls.assertEquals(line.qty_to_deliver, 0,
-                             "Wrong qty to deliver")
-            cls.assertEquals(line.qty_outgoing, 0,
-                             "Wrong qty outgoing")
-            cls.assertEquals(line.qty_delivered, 0,
-                             "Wrong qty delivered")
+            self.assertEquals(line.qty_received, 0,
+                              "Wrong qty received")
+            self.assertEquals(line.qty_to_deliver, 0,
+                              "Wrong qty to deliver")
+            self.assertEquals(line.qty_outgoing, 0,
+                              "Wrong qty outgoing")
+            self.assertEquals(line.qty_delivered, 0,
+                              "Wrong qty delivered")
             # product specific
-            if line.product_id == cls.product_1:
-                cls.assertEquals(line.qty_to_receive, 3,
-                                 "Wrong qty to receive")
-                cls.assertEquals(line.qty_incoming, 3,
-                                 "Wrong qty incoming")
-            if line.product_id == cls.product_2:
-                cls.assertEquals(line.qty_to_receive, 5,
-                                 "Wrong qty to receive")
-                cls.assertEquals(line.qty_incoming, 5,
-                                 "Wrong qty incoming")
-            if line.product_id == cls.product_3:
-                cls.assertEquals(line.qty_to_receive, 2,
-                                 "Wrong qty to receive")
-                cls.assertEquals(line.qty_incoming, 2,
-                                 "Wrong qty incoming")
+            if line.product_id == self.product_1:
+                self.assertEquals(line.qty_to_receive, 3,
+                                  "Wrong qty to receive")
+                self.assertEquals(line.qty_incoming, 3,
+                                  "Wrong qty incoming")
+            if line.product_id == self.product_2:
+                self.assertEquals(line.qty_to_receive, 5,
+                                  "Wrong qty to receive")
+                self.assertEquals(line.qty_incoming, 5,
+                                  "Wrong qty incoming")
+            if line.product_id == self.product_3:
+                self.assertEquals(line.qty_to_receive, 2,
+                                  "Wrong qty to receive")
+                self.assertEquals(line.qty_incoming, 2,
+                                  "Wrong qty incoming")
         picking.action_assign()
         for mv in picking.move_lines:
             mv.quantity_done = mv.product_uom_qty
         picking.action_done()
-        for line in cls.rma_customer_id.rma_line_ids:
-            cls.assertEquals(line.qty_to_receive, 0,
-                             "Wrong qty to_receive")
-            cls.assertEquals(line.qty_incoming, 0,
-                             "Wrong qty incoming")
-            cls.assertEquals(line.qty_outgoing, 0,
-                             "Wrong qty outgoing")
-            cls.assertEquals(line.qty_delivered, 0,
-                             "Wrong qty delivered")
-            if line.product_id == cls.product_1:
-                cls.assertEquals(line.qty_received, 3,
-                                 "Wrong qty received")
-                cls.assertEquals(line.qty_to_deliver, 3,
-                                 "Wrong qty to_deliver")
-            if line.product_id == cls.product_2:
-                cls.assertEquals(line.qty_received, 5,
-                                 "Wrong qty received")
-                cls.assertEquals(line.qty_to_deliver, 5,
-                                 "Wrong qty to_deliver")
-            if line.product_id == cls.product_3:
-                cls.assertEquals(line.qty_received, 2,
-                                 "Wrong qty received")
-                cls.assertEquals(line.qty_to_deliver, 2,
-                                 "Wrong qty to_deliver")
+        for line in self.rma_customer_id.rma_line_ids:
+            self.assertEquals(line.qty_to_receive, 0,
+                              "Wrong qty to_receive")
+            self.assertEquals(line.qty_incoming, 0,
+                              "Wrong qty incoming")
+            self.assertEquals(line.qty_outgoing, 0,
+                              "Wrong qty outgoing")
+            self.assertEquals(line.qty_delivered, 0,
+                              "Wrong qty delivered")
+            if line.product_id == self.product_1:
+                self.assertEquals(line.qty_received, 3,
+                                  "Wrong qty received")
+                self.assertEquals(line.qty_to_deliver, 3,
+                                  "Wrong qty to_deliver")
+            if line.product_id == self.product_2:
+                self.assertEquals(line.qty_received, 5,
+                                  "Wrong qty received")
+                self.assertEquals(line.qty_to_deliver, 5,
+                                  "Wrong qty to_deliver")
+            if line.product_id == self.product_3:
+                self.assertEquals(line.qty_received, 2,
+                                  "Wrong qty received")
+                self.assertEquals(line.qty_to_deliver, 2,
+                                  "Wrong qty to_deliver")
 
-        wizard = cls.rma_make_picking.with_context({
+        wizard = self.rma_make_picking.with_context({
             'active_id': 1,
-            'active_ids': cls.rma_customer_id.rma_line_ids.ids,
+            'active_ids': self.rma_customer_id.rma_line_ids.ids,
             'active_model': 'rma.order.line',
             'picking_type': 'outgoing',
         }).create({})
         wizard._create_picking()
-        res = cls.rma_customer_id.rma_line_ids.action_view_out_shipments()
-        cls.assertTrue('res_id' in res,
-                       "Incorrect number of pickings created")
-        picking = cls.env['stock.picking'].browse(res['res_id'])
+        res = self.rma_customer_id.rma_line_ids.action_view_out_shipments()
+        self.assertTrue('res_id' in res,
+                        "Incorrect number of pickings created")
+        picking = self.env['stock.picking'].browse(res['res_id'])
         moves = picking.move_lines
-        cls.assertEquals(len(moves), 3,
-                         "Incorrect number of moves created")
-        for line in cls.rma_customer_id.rma_line_ids:
-            cls.assertEquals(line.qty_to_receive, 0,
-                             "Wrong qty to receive")
-            cls.assertEquals(line.qty_incoming, 0,
-                             "Wrong qty incoming")
-            cls.assertEquals(line.qty_delivered, 0,
-                             "Wrong qty delivered")
-            if line.product_id == cls.product_1:
-                cls.assertEquals(line.qty_to_deliver, 3,
-                                 "Wrong qty to deliver")
-                cls.assertEquals(line.qty_outgoing, 3,
-                                 "Wrong qty outgoing")
-                cls.assertEquals(line.qty_received, 3,
-                                 "Wrong qty received")
-            if line.product_id == cls.product_2:
-                cls.assertEquals(line.qty_received, 5,
-                                 "Wrong qty received")
-                cls.assertEquals(line.qty_to_deliver, 5,
-                                 "Wrong qty to deliver")
-                cls.assertEquals(line.qty_outgoing, 5,
-                                 "Wrong qty outgoing")
-            if line.product_id == cls.product_3:
-                cls.assertEquals(line.qty_received, 2,
-                                 "Wrong qty received")
-                cls.assertEquals(line.qty_to_deliver, 2,
-                                 "Wrong qty to deliver")
-                cls.assertEquals(line.qty_outgoing, 2,
-                                 "Wrong qty outgoing")
+        self.assertEquals(len(moves), 3,
+                          "Incorrect number of moves created")
+        for line in self.rma_customer_id.rma_line_ids:
+            self.assertEquals(line.qty_to_receive, 0,
+                              "Wrong qty to receive")
+            self.assertEquals(line.qty_incoming, 0,
+                              "Wrong qty incoming")
+            self.assertEquals(line.qty_delivered, 0,
+                              "Wrong qty delivered")
+            if line.product_id == self.product_1:
+                self.assertEquals(line.qty_to_deliver, 3,
+                                  "Wrong qty to deliver")
+                self.assertEquals(line.qty_outgoing, 3,
+                                  "Wrong qty outgoing")
+                self.assertEquals(line.qty_received, 3,
+                                  "Wrong qty received")
+            if line.product_id == self.product_2:
+                self.assertEquals(line.qty_received, 5,
+                                  "Wrong qty received")
+                self.assertEquals(line.qty_to_deliver, 5,
+                                  "Wrong qty to deliver")
+                self.assertEquals(line.qty_outgoing, 5,
+                                  "Wrong qty outgoing")
+            if line.product_id == self.product_3:
+                self.assertEquals(line.qty_received, 2,
+                                  "Wrong qty received")
+                self.assertEquals(line.qty_to_deliver, 2,
+                                  "Wrong qty to deliver")
+                self.assertEquals(line.qty_outgoing, 2,
+                                  "Wrong qty outgoing")
         picking.action_assign()
         for mv in picking.move_lines:
             mv.quantity_done = mv.product_uom_qty
         picking.action_done()
-        for line in cls.rma_customer_id.rma_line_ids:
-            cls.assertEquals(line.qty_to_receive, 0,
-                             "Wrong qty to receive")
-            cls.assertEquals(line.qty_incoming, 0,
-                             "Wrong qty incoming")
-            cls.assertEquals(line.qty_to_deliver, 0,
-                             "Wrong qty to deliver")
-            cls.assertEquals(line.qty_outgoing, 0,
-                             "Wrong qty outgoing")
-            if line.product_id == cls.product_1:
-                cls.assertEquals(line.qty_received, 3,
-                                 "Wrong qty received")
-                cls.assertEquals(line.qty_delivered, 3,
-                                 "Wrong qty delivered")
-            if line.product_id == cls.product_2:
-                cls.assertEquals(line.qty_received, 5,
-                                 "Wrong qty received")
-                cls.assertEquals(line.qty_delivered, 5,
-                                 "Wrong qty delivered")
-            if line.product_id == cls.product_3:
-                cls.assertEquals(line.qty_received, 2,
-                                 "Wrong qty received")
-                cls.assertEquals(line.qty_delivered, 2,
-                                 "Wrong qty delivered")
-            cls.line.action_rma_done()
-            cls.assertEquals(cls.line.state, 'done',
-                             "Wrong State")
-        cls.rma_customer_id.action_view_in_shipments()
-        cls.rma_customer_id.action_view_out_shipments()
-        cls.rma_customer_id.action_view_lines()
+        for line in self.rma_customer_id.rma_line_ids:
+            self.assertEquals(line.qty_to_receive, 0,
+                              "Wrong qty to receive")
+            self.assertEquals(line.qty_incoming, 0,
+                              "Wrong qty incoming")
+            self.assertEquals(line.qty_to_deliver, 0,
+                              "Wrong qty to deliver")
+            self.assertEquals(line.qty_outgoing, 0,
+                              "Wrong qty outgoing")
+            if line.product_id == self.product_1:
+                self.assertEquals(line.qty_received, 3,
+                                  "Wrong qty received")
+                self.assertEquals(line.qty_delivered, 3,
+                                  "Wrong qty delivered")
+            if line.product_id == self.product_2:
+                self.assertEquals(line.qty_received, 5,
+                                  "Wrong qty received")
+                self.assertEquals(line.qty_delivered, 5,
+                                  "Wrong qty delivered")
+            if line.product_id == self.product_3:
+                self.assertEquals(line.qty_received, 2,
+                                  "Wrong qty received")
+                self.assertEquals(line.qty_delivered, 2,
+                                  "Wrong qty delivered")
+            self.line.action_rma_done()
+            self.assertEquals(self.line.state, 'done',
+                              "Wrong State")
+        self.rma_customer_id.action_view_in_shipments()
+        self.rma_customer_id.action_view_out_shipments()
+        self.rma_customer_id.action_view_lines()
 
     # DROPSHIP
-    def test_03_dropship(cls):
-        for line in cls.rma_droship_id.rma_line_ids:
+    def test_03_dropship(self):
+        for line in self.rma_droship_id.rma_line_ids:
             line.action_rma_to_approve()
             line.action_rma_approve()
             line._onchange_operation_id()
-        wizard = cls.rma_make_picking.with_context({
+        wizard = self.rma_make_picking.with_context({
             'active_id': 1,
-            'active_ids': cls.rma_droship_id.rma_line_ids.ids,
+            'active_ids': self.rma_droship_id.rma_line_ids.ids,
             'active_model': 'rma.order.line',
             'picking_type': 'incoming',
         }).create({})
         wizard._create_picking()
-        res = cls.rma_droship_id.rma_line_ids.action_view_in_shipments()
-        cls.assertTrue('res_id' in res,
-                       "Incorrect number of pickings created")
-        picking = cls.env['stock.picking'].browse(res['res_id'])
-        cls.assertEquals(len(picking), 1,
-                         "Incorrect number of pickings created")
+        res = self.rma_droship_id.rma_line_ids.action_view_in_shipments()
+        self.assertTrue('res_id' in res,
+                        "Incorrect number of pickings created")
+        picking = self.env['stock.picking'].browse(res['res_id'])
+        self.assertEquals(len(picking), 1,
+                          "Incorrect number of pickings created")
         moves = picking.move_lines
-        cls.assertEquals(len(moves), 3,
-                         "Incorrect number of moves created")
-        wizard = cls.make_supplier_rma.with_context({
-            'active_ids': cls.rma_droship_id.rma_line_ids.ids,
+        self.assertEquals(len(moves), 3,
+                          "Incorrect number of moves created")
+        wizard = self.make_supplier_rma.with_context({
+            'active_ids': self.rma_droship_id.rma_line_ids.ids,
             'active_model': 'rma.order.line',
             'active_id': 1
         }).create({})
         res = wizard.make_supplier_rma()
-        supplier_rma = cls.rma.browse(res['res_id'])
+        supplier_rma = self.rma.browse(res['res_id'])
         for line in supplier_rma.rma_line_ids:
             # common qtys for all products
-            cls.assertEquals(line.qty_received, 0,
-                             "Wrong qty received")
-            cls.assertEquals(line.qty_outgoing, 0,
-                             "Wrong qty incoming")
-            cls.assertEquals(line.qty_delivered, 0,
-                             "Wrong qty delivered")
+            self.assertEquals(line.qty_received, 0,
+                              "Wrong qty received")
+            self.assertEquals(line.qty_outgoing, 0,
+                              "Wrong qty incoming")
+            self.assertEquals(line.qty_delivered, 0,
+                              "Wrong qty delivered")
             # product specific
-            if line.product_id == cls.product_1:
-                cls.assertEquals(line.qty_to_deliver, 3,
-                                 "Wrong qty to deliver")
-            if line.product_id == cls.product_2:
-                cls.assertEquals(line.qty_to_deliver, 5,
-                                 "Wrong qty to deliver")
-            if line.product_id == cls.product_3:
-                cls.assertEquals(line.qty_to_deliver, 2,
-                                 "Wrong qty to deliver")
+            if line.product_id == self.product_1:
+                self.assertEquals(line.qty_to_deliver, 3,
+                                  "Wrong qty to deliver")
+            if line.product_id == self.product_2:
+                self.assertEquals(line.qty_to_deliver, 5,
+                                  "Wrong qty to deliver")
+            if line.product_id == self.product_3:
+                self.assertEquals(line.qty_to_deliver, 2,
+                                  "Wrong qty to deliver")
 
-        for line in cls.rma_droship_id.rma_line_ids:
-            if line.product_id == cls.product_1:
-                cls.assertEquals(line.qty_to_supplier_rma, 0,
-                                 "Wrong qty to supplier rma")
-                cls.assertEquals(line.qty_in_supplier_rma, 3,
-                                 "Wrong qty in supplier rma")
-            if line.product_id == cls.product_2:
-                cls.assertEquals(line.qty_to_supplier_rma, 0,
-                                 "Wrong qty to supplier rma")
-                cls.assertEquals(line.qty_in_supplier_rma, 5,
-                                 "Wrong qty in supplier rma")
-            if line.product_id == cls.product_3:
-                cls.assertEquals(line.qty_to_supplier_rma, 0,
-                                 "Wrong qty to supplier rma")
-                cls.assertEquals(line.qty_in_supplier_rma, 2,
-                                 "Wrong qty in supplier rma")
-        for line in cls.rma_droship_id.rma_line_ids:
+        for line in self.rma_droship_id.rma_line_ids:
+            if line.product_id == self.product_1:
+                self.assertEquals(line.qty_to_supplier_rma, 0,
+                                  "Wrong qty to supplier rma")
+                self.assertEquals(line.qty_in_supplier_rma, 3,
+                                  "Wrong qty in supplier rma")
+            if line.product_id == self.product_2:
+                self.assertEquals(line.qty_to_supplier_rma, 0,
+                                  "Wrong qty to supplier rma")
+                self.assertEquals(line.qty_in_supplier_rma, 5,
+                                  "Wrong qty in supplier rma")
+            if line.product_id == self.product_3:
+                self.assertEquals(line.qty_to_supplier_rma, 0,
+                                  "Wrong qty to supplier rma")
+                self.assertEquals(line.qty_in_supplier_rma, 2,
+                                  "Wrong qty in supplier rma")
+        for line in self.rma_droship_id.rma_line_ids:
             line.action_rma_done()
-            cls.assertEquals(line.state, 'done',
-                             "Wrong State")
+            self.assertEquals(line.state, 'done',
+                              "Wrong State")
 
     # Supplier RMA
-    def test_04_supplier_rma(cls):
-        wizard = cls.rma_make_picking.with_context({
-            'active_ids': cls.rma_supplier_id.rma_line_ids.ids,
+    def test_04_supplier_rma(self):
+        wizard = self.rma_make_picking.with_context({
+            'active_ids': self.rma_supplier_id.rma_line_ids.ids,
             'active_model': 'rma.order.line',
             'picking_type': 'outgoing',
             'active_id': 1
         }).create({})
         wizard._create_picking()
-        res = cls.rma_supplier_id.rma_line_ids.action_view_out_shipments()
-        cls.assertTrue('res_id' in res,
-                       "Incorrect number of pickings created")
-        picking = cls.env['stock.picking'].browse(res['res_id'])
+        res = self.rma_supplier_id.rma_line_ids.action_view_out_shipments()
+        self.assertTrue('res_id' in res,
+                        "Incorrect number of pickings created")
+        picking = self.env['stock.picking'].browse(res['res_id'])
         moves = picking.move_lines
-        cls.assertEquals(len(moves), 3,
-                         "Incorrect number of moves created")
-        for line in cls.rma_supplier_id.rma_line_ids:
+        self.assertEquals(len(moves), 3,
+                          "Incorrect number of moves created")
+        for line in self.rma_supplier_id.rma_line_ids:
             # common qtys for all products
-            cls.assertEquals(line.qty_received, 0,
-                             "Wrong qty received")
-            cls.assertEquals(line.qty_incoming, 0,
-                             "Wrong qty incoming")
-            cls.assertEquals(line.qty_delivered, 0,
-                             "Wrong qty delivered")
+            self.assertEquals(line.qty_received, 0,
+                              "Wrong qty received")
+            self.assertEquals(line.qty_incoming, 0,
+                              "Wrong qty incoming")
+            self.assertEquals(line.qty_delivered, 0,
+                              "Wrong qty delivered")
             # product specific
-            if line.product_id == cls.product_1:
-                cls.assertEquals(line.qty_to_receive, 3,
-                                 "Wrong qty to receive")
-                cls.assertEquals(line.qty_to_deliver, 3,
-                                 "Wrong qty to deliver")
-                cls.assertEquals(line.qty_outgoing, 3,
-                                 "Wrong qty outgoing")
-            if line.product_id == cls.product_2:
-                cls.assertEquals(line.qty_to_receive, 5,
-                                 "Wrong qty to receive")
-                cls.assertEquals(line.qty_to_deliver, 5,
-                                 "Wrong qty to deliver")
-                cls.assertEquals(line.qty_outgoing, 5,
-                                 "Wrong qty outgoing")
-            if line.product_id == cls.product_3:
-                cls.assertEquals(line.qty_to_receive, 2,
-                                 "Wrong qty to receive")
-                cls.assertEquals(line.qty_to_deliver, 2,
-                                 "Wrong qty to deliver")
-                cls.assertEquals(line.qty_outgoing, 2,
-                                 "Wrong qty outgoing")
+            if line.product_id == self.product_1:
+                self.assertEquals(line.qty_to_receive, 3,
+                                  "Wrong qty to receive")
+                self.assertEquals(line.qty_to_deliver, 3,
+                                  "Wrong qty to deliver")
+                self.assertEquals(line.qty_outgoing, 3,
+                                  "Wrong qty outgoing")
+            if line.product_id == self.product_2:
+                self.assertEquals(line.qty_to_receive, 5,
+                                  "Wrong qty to receive")
+                self.assertEquals(line.qty_to_deliver, 5,
+                                  "Wrong qty to deliver")
+                self.assertEquals(line.qty_outgoing, 5,
+                                  "Wrong qty outgoing")
+            if line.product_id == self.product_3:
+                self.assertEquals(line.qty_to_receive, 2,
+                                  "Wrong qty to receive")
+                self.assertEquals(line.qty_to_deliver, 2,
+                                  "Wrong qty to deliver")
+                self.assertEquals(line.qty_outgoing, 2,
+                                  "Wrong qty outgoing")
 
         picking.action_assign()
         for mv in picking.move_lines:
             mv.quantity_done = mv.product_uom_qty
         picking.action_done()
-        for line in cls.rma_supplier_id.rma_line_ids:
-            cls.assertEquals(line.qty_incoming, 0,
-                             "Wrong qty incoming")
-            cls.assertEquals(line.qty_received, 0,
-                             "Wrong qty received")
-            if line.product_id == cls.product_1:
-                cls.assertEquals(line.qty_delivered, 3,
-                                 "Wrong qty delivered")
-                cls.assertEquals(line.qty_to_receive, 3,
-                                 "Wrong qty to receive")
-            if line.product_id == cls.product_2:
-                cls.assertEquals(line.qty_delivered, 5,
-                                 "Wrong qty delivered")
-                cls.assertEquals(line.qty_to_receive, 5,
-                                 "Wrong qty to receive")
-            if line.product_id == cls.product_3:
-                cls.assertEquals(line.qty_delivered, 2,
-                                 "Wrong qty delivered")
-                cls.assertEquals(line.qty_to_receive, 2,
-                                 "Wrong qty to receive")
-        wizard = cls.rma_make_picking.with_context({
+        for line in self.rma_supplier_id.rma_line_ids:
+            self.assertEquals(line.qty_incoming, 0,
+                              "Wrong qty incoming")
+            self.assertEquals(line.qty_received, 0,
+                              "Wrong qty received")
+            if line.product_id == self.product_1:
+                self.assertEquals(line.qty_delivered, 3,
+                                  "Wrong qty delivered")
+                self.assertEquals(line.qty_to_receive, 3,
+                                  "Wrong qty to receive")
+            if line.product_id == self.product_2:
+                self.assertEquals(line.qty_delivered, 5,
+                                  "Wrong qty delivered")
+                self.assertEquals(line.qty_to_receive, 5,
+                                  "Wrong qty to receive")
+            if line.product_id == self.product_3:
+                self.assertEquals(line.qty_delivered, 2,
+                                  "Wrong qty delivered")
+                self.assertEquals(line.qty_to_receive, 2,
+                                  "Wrong qty to receive")
+        wizard = self.rma_make_picking.with_context({
             'active_id': 1,
-            'active_ids': cls.rma_supplier_id.rma_line_ids.ids,
+            'active_ids': self.rma_supplier_id.rma_line_ids.ids,
             'active_model': 'rma.order.line',
             'picking_type': 'incoming',
         }).create({})
         wizard._create_picking()
-        res = cls.rma_supplier_id.rma_line_ids.action_view_in_shipments()
-        cls.assertTrue('res_id' in res,
-                       "Incorrect number of pickings created")
-        pickings = cls.env['stock.picking'].browse(res['res_id'])
-        cls.assertEquals(len(pickings), 1,
-                         "Incorrect number of pickings created")
+        res = self.rma_supplier_id.rma_line_ids.action_view_in_shipments()
+        self.assertTrue('res_id' in res,
+                        "Incorrect number of pickings created")
+        pickings = self.env['stock.picking'].browse(res['res_id'])
+        self.assertEquals(len(pickings), 1,
+                          "Incorrect number of pickings created")
         picking_out = pickings[0]
         moves = picking_out.move_lines
-        cls.assertEquals(len(moves), 3,
-                         "Incorrect number of moves created")
-        for line in cls.rma_supplier_id.rma_line_ids:
-            cls.assertEquals(line.qty_incoming, 0,
-                             "Wrong qty incoming")
-            cls.assertEquals(line.qty_received, 0,
-                             "Wrong qty received")
-            cls.assertEquals(line.qty_to_deliver, 0,
-                             "Wrong qty to deliver")
-            if line.product_id == cls.product_1:
-                cls.assertEquals(line.qty_to_receive, 3,
-                                 "Wrong qty to receive")
-                cls.assertEquals(line.qty_incoming, 0,
-                                 "Wrong qty incoming")
-            if line.product_id == cls.product_2:
-                cls.assertEquals(line.qty_to_receive, 5,
-                                 "Wrong qty to receive")
-            if line.product_id == cls.product_3:
-                cls.assertEquals(line.qty_to_receive, 2,
-                                 "Wrong qty to receive")
+        self.assertEquals(len(moves), 3,
+                          "Incorrect number of moves created")
+        for line in self.rma_supplier_id.rma_line_ids:
+            self.assertEquals(line.qty_incoming, 0,
+                              "Wrong qty incoming")
+            self.assertEquals(line.qty_received, 0,
+                              "Wrong qty received")
+            self.assertEquals(line.qty_to_deliver, 0,
+                              "Wrong qty to deliver")
+            if line.product_id == self.product_1:
+                self.assertEquals(line.qty_to_receive, 3,
+                                  "Wrong qty to receive")
+                self.assertEquals(line.qty_incoming, 0,
+                                  "Wrong qty incoming")
+            if line.product_id == self.product_2:
+                self.assertEquals(line.qty_to_receive, 5,
+                                  "Wrong qty to receive")
+            if line.product_id == self.product_3:
+                self.assertEquals(line.qty_to_receive, 2,
+                                  "Wrong qty to receive")
         picking_out.action_assign()
         for mv in picking.move_lines:
             mv.quantity_done = mv.product_uom_qty
         picking_out.action_done()
-        for line in cls.rma_supplier_id.rma_line_ids[0]:
-            cls.assertEquals(line.qty_to_receive, 3,
-                             "Wrong qty to receive")
-            cls.assertEquals(line.qty_incoming, 0,
-                             "Wrong qty incoming")
-            cls.assertEquals(line.qty_to_deliver, 0,
-                             "Wrong qty to deliver")
-            cls.assertEquals(line.qty_outgoing, 3,
-                             "Wrong qty outgoing")
-            if line.product_id == cls.product_1:
-                cls.assertEquals(line.qty_received, 0,
-                                 "Wrong qty received")
-                cls.assertEquals(line.qty_delivered, 3,
-                                 "Wrong qty delivered")
-            if line.product_id == cls.product_2:
-                cls.assertEquals(line.qty_received, 0,
-                                 "Wrong qty received")
-                cls.assertEquals(line.qty_delivered, 5,
-                                 "Wrong qty delivered")
-            if line.product_id == cls.product_3:
-                cls.assertEquals(line.qty_received, 2,
-                                 "Wrong qty received")
-                cls.assertEquals(line.qty_delivered, 2,
-                                 "Wrong qty delivered")
-        for line in cls.rma_supplier_id.rma_line_ids:
+        for line in self.rma_supplier_id.rma_line_ids[0]:
+            self.assertEquals(line.qty_to_receive, 3,
+                              "Wrong qty to receive")
+            self.assertEquals(line.qty_incoming, 0,
+                              "Wrong qty incoming")
+            self.assertEquals(line.qty_to_deliver, 0,
+                              "Wrong qty to deliver")
+            self.assertEquals(line.qty_outgoing, 3,
+                              "Wrong qty outgoing")
+            if line.product_id == self.product_1:
+                self.assertEquals(line.qty_received, 0,
+                                  "Wrong qty received")
+                self.assertEquals(line.qty_delivered, 3,
+                                  "Wrong qty delivered")
+            if line.product_id == self.product_2:
+                self.assertEquals(line.qty_received, 0,
+                                  "Wrong qty received")
+                self.assertEquals(line.qty_delivered, 5,
+                                  "Wrong qty delivered")
+            if line.product_id == self.product_3:
+                self.assertEquals(line.qty_received, 2,
+                                  "Wrong qty received")
+                self.assertEquals(line.qty_delivered, 2,
+                                  "Wrong qty delivered")
+        for line in self.rma_supplier_id.rma_line_ids:
             line.action_rma_done()
-            cls.assertEquals(line.state, 'done',
-                             "Wrong State")
+            self.assertEquals(line.state, 'done',
+                              "Wrong State")

--- a/rma_internal_transfer/README.rst
+++ b/rma_internal_transfer/README.rst
@@ -1,0 +1,44 @@
+.. image:: https://img.shields.io/badge/license-LGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/lgpl
+   :alt: License: LGPL-3
+
+=====================
+RMA Internal Transfer
+=====================
+
+Sometimes the repair location is not the same as the receiving location
+and useres wants to perform this action manual instead of putaway
+strategies. In this case an internal tranfer has to be done.
+
+This module just adds a button that eases this task
+
+
+Usage
+=====
+
+In the RMA from view there is a new button "Internal Transfer". The user
+just need to change the default location according its needs.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/Eficent/stock-rma/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Aaron Henriquez <ahenriquez@eficent.com>
+
+
+Maintainer
+----------
+
+This module is maintained by Eficent.

--- a/rma_internal_transfer/__init__.py
+++ b/rma_internal_transfer/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from . import wizards

--- a/rma_internal_transfer/__manifest__.py
+++ b/rma_internal_transfer/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+{
+    'name': 'RMA Internal Transfer',
+    'version': '12.0.2.3.0',
+    'license': 'LGPL-3',
+    'category': 'RMA',
+    'summary': 'Internal transfers. Made easy.',
+    'author': "Eficent, Odoo Community Association (OCA)",
+    'website': 'https://github.com/Eficent/stock-rma',
+    'depends': ['rma'],
+    'data': ['wizards/rma_internal_transfer.xml',
+             ],
+    'installable': True,
+}

--- a/rma_internal_transfer/tests/__init__.py
+++ b/rma_internal_transfer/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_internal_transfer

--- a/rma_internal_transfer/tests/test_internal_transfer.py
+++ b/rma_internal_transfer/tests/test_internal_transfer.py
@@ -1,0 +1,132 @@
+# © 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from odoo.tests import common
+
+
+class TestRmaInternalTransfer(common.SavepointCase):
+    """ Test the routes and the quantities """
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestRmaInternalTransfer, cls).setUpClass()
+
+        cls.rma_make_picking = cls.env['rma_internal_transfer.wizard']
+        cls.stockpicking = cls.env['stock.picking']
+        cls.rma_add_stock_move = cls.env['rma_add_stock_move']
+        cls.rma = cls.env['rma.order']
+        cls.rma_line = cls.env['rma.order.line']
+        cls.product_1 = cls.env.ref('product.product_product_25')
+        cls.partner_id = cls.env.ref('base.res_partner_2')
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        wh = cls.env.ref('stock.warehouse0')
+        cls.product_uom_id = cls.env.ref('uom.product_uom_unit')
+        cls.stock_rma_location = wh.lot_rma_id
+        cls.customer_location = cls.env.ref(
+            'stock.stock_location_customers')
+        cls.supplier_location = cls.env.ref(
+            'stock.stock_location_suppliers')
+        # Customer RMA:
+        products2move = [(cls.product_1, 3)]
+        cls.rma_customer_id = cls._create_rma_from_move(
+            products2move, 'customer', cls.env.ref('base.res_partner_2'),
+            dropship=False)
+        cls.rma_customer_id.rma_line_ids._onchange_operation_id()
+        seq = cls.env['ir.sequence'].search([], limit=1)
+        cls.env['stock.picking.type'].create({
+            "name": "TEST INTERNAL",
+            "sequence_id": seq.id,
+            "default_location_src_id": cls.stock_rma_location.id,
+            "default_location_dest_id": cls.stock_rma_location.id,
+            "warehouse_id": wh.id,
+            "code": "internal"})
+
+    @classmethod
+    def _create_picking(cls, partner):
+        return cls.stockpicking.create({
+            'partner_id': partner.id,
+            'picking_type_id': cls.env.ref('stock.picking_type_in').id,
+            'location_id': cls.stock_location.id,
+            'location_dest_id': cls.supplier_location.id
+            })
+
+    @classmethod
+    def _prepare_move(cls, product, qty, src, dest, picking_in):
+        res = {
+            'partner_id': cls.partner_id.id,
+            'product_id': product.id,
+            'name': product.partner_ref,
+            'state': 'confirmed',
+            'product_uom': cls.product_uom_id.id or product.uom_id.id,
+            'product_uom_qty': qty,
+            'origin': 'Test RMA',
+            'location_id': src.id,
+            'location_dest_id': dest.id,
+            'picking_id': picking_in.id
+        }
+        return res
+
+    @classmethod
+    def _create_rma_from_move(cls, products2move, type, partner, dropship,
+                              supplier_address_id=None):
+        picking_in = cls._create_picking(partner)
+
+        moves = []
+        for item in products2move:
+            move_values = cls._prepare_move(
+                item[0], item[1], cls.stock_location,
+                cls.customer_location, picking_in)
+            moves.append(cls.env['stock.move'].create(move_values))
+
+        # Create the RMA from the stock_move
+        rma_id = cls.rma.create(
+            {
+                'reference': '0001',
+                'type': type,
+                'partner_id': partner.id,
+                'company_id': cls.env.ref('base.main_company').id
+            })
+        for move in moves:
+            if type == 'customer':
+                wizard = cls.rma_add_stock_move.new(
+                    {'stock_move_id': move.id, 'customer': True,
+                     'active_ids': rma_id.id,
+                     'rma_id': rma_id.id,
+                     'partner_id': move.partner_id.id,
+                     'active_model': 'rma.order',
+                     }
+                )
+                wizard.with_context({
+                    'stock_move_id': move.id, 'customer': True,
+                    'active_ids': rma_id.id,
+                    'partner_id': move.partner_id.id,
+                    'active_model': 'rma.order',
+                }).default_get([str(move.id),
+                                str(cls.partner_id.id)])
+                data = wizard.with_context(customer=1).\
+                    _prepare_rma_line_from_stock_move(move)
+                wizard.add_lines()
+
+                for operation in move.product_id.rma_customer_operation_id:
+                    operation.in_route_id = False
+                move.product_id.categ_id.rma_customer_operation_id = False
+                move.product_id.rma_customer_operation_id = False
+                wizard._prepare_rma_line_from_stock_move(move)
+
+            cls.line = cls.rma_line.create(data)
+            cls.line.action_rma_to_approve()
+            cls.line.action_rma_approve()
+        return rma_id
+
+    def test_0_internal_transfer(cls):
+        wizard = cls.rma_make_picking.with_context({
+            'active_ids': cls.rma_customer_id.rma_line_ids.ids,
+            'active_model': 'rma.order.line',
+            'picking_type': 'internal',
+            'active_id': cls.rma_customer_id.id
+        }).create({})
+
+        wizard.action_create_picking()
+        res = cls.rma_customer_id.rma_line_ids.action_view_in_shipments()
+        cls.assertTrue('res_id' in res,
+                       "Incorrect number of pickings created")

--- a/rma_internal_transfer/wizards/__init__.py
+++ b/rma_internal_transfer/wizards/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from . import rma_internal_transfer

--- a/rma_internal_transfer/wizards/rma_internal_transfer.py
+++ b/rma_internal_transfer/wizards/rma_internal_transfer.py
@@ -1,0 +1,147 @@
+# Copyright (C) 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError, ValidationError
+import odoo.addons.decimal_precision as dp
+
+
+class RmaMakePicking(models.TransientModel):
+    _name = 'rma_internal_transfer.wizard'
+    _description = 'Wizard to create pickings from rma lines'
+
+    @api.returns('rma.order.line')
+    def _prepare_item(self, line):
+        values = {'product_id': line.product_id.id,
+                  'product_qty': line.product_qty,
+                  'uom_id': line.uom_id.id,
+                  'qty_to_receive': line.qty_to_receive,
+                  'qty_to_deliver': line.qty_to_deliver,
+                  'line_id': line.id,
+                  'rma_id': line.rma_id and line.rma_id.id or False,
+                  'wiz_id': self.env.context['active_id'],
+                  }
+        return values
+
+    @api.model
+    def default_get(self, fields):
+        """Default values for wizard, if there is more than one supplier on
+        lines the supplier field is empty otherwise is the unique line
+        supplier.
+        """
+        context = self._context.copy()
+        res = super(RmaMakePicking, self).default_get(fields)
+        rma_line_obj = self.env['rma.order.line']
+        rma_line_ids = self.env.context['active_ids'] or []
+        active_model = self.env.context['active_model']
+
+        if not rma_line_ids:
+            return res
+        assert active_model == 'rma.order.line', \
+            'Bad context propagation'
+
+        items = []
+        lines = rma_line_obj.browse(rma_line_ids)
+        if len(lines.mapped('partner_id')) > 1:
+            raise ValidationError(
+                _('Only RMA lines from the same partner can be processed at '
+                  'the same time'))
+        for line in lines:
+            items.append([0, 0, self._prepare_item(line)])
+
+        types = self.env['stock.picking.type'].search(
+            [('code', '=', 'internal'),
+             ('warehouse_id.company_id', '=',
+              line.in_warehouse_id.id)])[:1]
+        if not types:
+            raise ValidationError(_('Please define an internal picking type '
+                                    'for this warehouse'))
+        res['location_id'] = lines.mapped('location_id').ids[0]
+        res['picking_type_id'] = types.id
+        res['location_dest_id'] = lines.mapped('location_id').ids[0]
+        res['item_ids'] = items
+        context.update({'items_ids': items})
+        return res
+
+    item_ids = fields.One2many(
+        'rma_internal_transfer.wizard.item',
+        'wiz_id', string='Items')
+    picking_type_id = fields.Many2one('stock.picking.type', 'Operation Type',
+                                      required=True)
+    location_id = fields.Many2one('stock.location', 'Source Location',
+                                  required=True)
+    location_dest_id = fields.Many2one(
+        'stock.location', 'Destination Location', required=True)
+
+    def find_procurement_group(self):
+        if self.mapped('item_ids.line_id.rma_id'):
+            return self.env['procurement.group'].search([
+                ('rma_id', 'in', self.mapped('item_ids.line_id.rma_id').ids)])
+        else:
+            return self.env['procurement.group'].search([
+                ('rma_line_id', 'in', self.mapped('item_ids.line_id').ids)])
+
+    @api.multi
+    def action_create_picking(self):
+        self.ensure_one()
+        picking_obj = self.env['stock.picking']
+        type_obj = self.env['stock.picking.type']
+        user_obj = self.env['res.users']
+        company_id = user_obj.browse(self._uid).company_id.id
+        types = type_obj.search([('code', '=', 'internal'),
+                                 ('warehouse_id.company_id', '=', company_id)])
+        if not types:
+            raise UserError(_("Make sure you have at least an internal picking"
+                              "type defined for your company's warehouse."))
+        picking_type = types[0]
+        group_id = self.find_procurement_group().id
+        picking = picking_obj.create({
+            'picking_type_id': picking_type.id,
+            'location_dest_id': self.location_dest_id.id,
+            'location_id': self.location_id.id,
+            'move_lines': [(0, 0, {
+                'name': item.line_id.name,
+                'product_id': item.product_id.id,
+                'product_uom_qty': item.product_qty,
+                'product_uom': item.uom_id.id,
+                'state': 'draft',
+                'group_id': group_id,
+                'rma_line_id': item.line_id.id,
+            }) for item in self.item_ids]
+        })
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Stock Picking',
+            'res_model': 'stock.picking',
+            'res_id': picking.id,
+            'view_mode': 'form',
+            'view_type': 'form',
+        }
+
+    @api.multi
+    def action_cancel(self):
+        return {'type': 'ir.actions.act_window_close'}
+
+
+class RmaMakePickingItem(models.TransientModel):
+    _name = "rma_internal_transfer.wizard.item"
+    _description = "Items to receive"
+
+    wiz_id = fields.Many2one(
+        'rma_internal_transfer.wizard',
+        string='Wizard', required=True)
+    line_id = fields.Many2one('rma.order.line',
+                              string='RMA order Line',
+                              readonly=True,
+                              ondelete='cascade')
+    rma_id = fields.Many2one('rma.order',
+                             related='line_id.rma_id',
+                             string='RMA Group',
+                             readonly=True)
+    product_id = fields.Many2one('product.product', string='Product',
+                                 required=True)
+    product_qty = fields.Float(
+        related='line_id.product_qty',
+        string='Quantity Ordered', copy=False,
+        digits=dp.get_precision('Product Unit of Measure'))
+    uom_id = fields.Many2one('uom.uom', string='Unit of Measure')

--- a/rma_internal_transfer/wizards/rma_internal_transfer.xml
+++ b/rma_internal_transfer/wizards/rma_internal_transfer.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+
+<odoo>
+
+    <record id="view_rma_picking_internal" model="ir.ui.view">
+        <field name="name">Internal Transfer</field>
+        <field name="model">rma_internal_transfer.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Select lines for transfer" name="lines">
+                <separator string="Select lines for picking"/>
+                <group name="main">
+                    <group name="locations">
+                        <field name="picking_type_id"/>
+                        <field name="location_id"/>
+                        <field name="location_dest_id"/>
+                    </group>
+                </group>
+                <field name="item_ids">
+                    <tree string="RMA Lines" editable="bottom" create="false">
+                        <field name="rma_id" groups="rma.group_rma_groups"/>
+                        <field name="product_id"/>
+                        <field name="product_qty"/>
+                        <field name="uom_id" groups="uom.group_uom"/>
+                    </tree>
+                </field>
+                <footer>
+                    <button
+                            string="Confirm"
+                            name="action_create_picking" type="object"
+                            class="oe_highlight"/>
+                    or
+                    <button name="action_cancel"
+                            string="Cancel" class="oe_link" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_rma_picking_internal" model="ir.actions.act_window">
+        <field name="name">Create Internal Transfer</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">rma_internal_transfer.wizard</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="view_id" ref="view_rma_picking_internal"/>
+        <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]"/>
+        <field name="context">{'picking_type': 'internal'}</field>
+        <field name="binding_model_id" ref="rma.model_rma_order_line"/>
+    </record>
+
+    <record id="view_rma_line_button_form" model="ir.ui.view">
+        <field name="name">rma.order.line.form</field>
+        <field name="model">rma.order.line</field>
+        <field name="inherit_id" ref="rma.view_rma_line_form"/>
+        <field name="arch" type="xml">
+            <button name="%(rma.action_rma_picking_out)d" position="after">
+                <button name="%(action_rma_picking_internal)d" states="approved"
+                        string="Internal Transfer" class="oe_highlight"
+                        type="action"/>
+            </button>
+        </field>
+    </record>
+
+    <record id="view_rma_line_supplier_button_form" model="ir.ui.view">
+        <field name="name">rma.order.line.supplier.form</field>
+        <field name="model">rma.order.line</field>
+        <field name="inherit_id" ref="rma.view_rma_line_supplier_button_form"/>
+        <field name="arch" type="xml">
+            <button name="%(rma.action_rma_picking_out)d" position="after">
+                <button name="%(action_rma_picking_internal)d" states="approved"
+                        string="Internal Transfer" class="oe_highlight"
+                        type="action"/>
+            </button>
+        </field>
+    </record>
+
+</odoo>

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
-from openerp.tests import common
+from odoo.tests import common
 
 
 class TestRmaSale(common.SingleTransactionCase):


### PR DESCRIPTION
Sometimes the repair location is not the same as the receiving location and users wants to perform this action manual instead of push rules. In this case an internal transfer has to be done.

This module just adds a button that eases this task