### PR TITLE
[12.0][UPT]allow to deliver rmas after repair even when not paid

### DIFF
--- a/rma_repair/__manifest__.py
+++ b/rma_repair/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "RMA Repair",
-    "version": "12.0.1.2.0",
+    "version": "12.0.1.2.1",
     "license": "LGPL-3",
     "category": "RMA",
     "summary": "Links RMA with Repairs.",

--- a/rma_repair/models/rma_order_line.py
+++ b/rma_repair/models/rma_order_line.py
@@ -144,3 +144,8 @@ class RmaOrderLine(models.Model):
         for rec in self.filtered(lambda l: l.delivery_policy == 'repair'):
             rec.qty_to_deliver = rec.qty_repaired - rec.qty_delivered
         return res
+
+    def rma_repair_make_invoice(self):
+        res = self.env['repair.order.make_invoice'].with_context(
+            active_ids=self.repair_ids.ids).create({}).make_invoices()
+        return res

--- a/rma_repair/models/rma_order_line.py
+++ b/rma_repair/models/rma_order_line.py
@@ -142,6 +142,5 @@ class RmaOrderLine(models.Model):
     def _compute_qty_to_deliver(self):
         res = super(RmaOrderLine, self)._compute_qty_to_deliver()
         for rec in self.filtered(lambda l: l.delivery_policy == 'repair'):
-            rec.qty_to_deliver = rec.qty_repaired - rec.qty_delivered - \
-                rec.qty_to_pay
+            rec.qty_to_deliver = rec.qty_repaired - rec.qty_delivered
         return res

--- a/rma_repair/models/rma_order_line.py
+++ b/rma_repair/models/rma_order_line.py
@@ -147,5 +147,5 @@ class RmaOrderLine(models.Model):
 
     def rma_repair_make_invoice(self):
         res = self.env['repair.order.make_invoice'].with_context(
-            active_ids=self.repair_ids.ids).create({}).make_invoices()
+            active_ids=self.repair_ids.ids).create({'group': True}).make_invoices()
         return res

--- a/rma_repair/tests/test_rma_repair.py
+++ b/rma_repair/tests/test_rma_repair.py
@@ -242,7 +242,7 @@ class TestRmaRepair(common.SingleTransactionCase):
         repair.action_repair_invoice_create()
         self.assertEqual(rma.qty_repaired, 1.0)
         repair.invoice_id.action_invoice_open()
-        self.assertEqual(rma.qty_to_deliver, 0.0)
+        self.assertEqual(rma.qty_to_deliver, 1.0)
         repair.invoice_id.pay_and_reconcile(self.bank_journal, 200.0)
         self.assertEqual(repair.invoice_status, 'paid')
         self.assertEqual(rma.qty_to_pay, 0.0)

--- a/rma_repair/views/rma_order_line_view.xml
+++ b/rma_repair/views/rma_order_line_view.xml
@@ -45,6 +45,12 @@
                         string="Create Repair Order"
                         class="oe_highlight"
                         type="action"/>
+                <button name="rma_repair_make_invoice"
+                        states="approved"
+                        string="Create Repair Invoices"
+                        class="oe_highlight"
+                        attrs="{'invisible':[('repair_count', '=', 0)]}"
+                        type="object"/>
             </header>
         </field>
     </record>

--- a/rma_repair/views/rma_order_line_view.xml
+++ b/rma_repair/views/rma_order_line_view.xml
@@ -55,4 +55,15 @@
         </field>
     </record>
 
+    <record id="action_rma_order_line_make_repair_invoice"
+            model="ir.actions.act_window">
+        <field name="name">Create Repair Invoices</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">repair.order.make_invoice</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="rma_repair.model_rma_order_line"/>
+    </record>
+
 </odoo>

--- a/rma_repair/wizards/__init__.py
+++ b/rma_repair/wizards/__init__.py
@@ -1,3 +1,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
 from . import rma_order_line_make_repair
+from . import repair_make_invoice

--- a/rma_repair/wizards/repair_make_invoice.py
+++ b/rma_repair/wizards/repair_make_invoice.py
@@ -1,0 +1,17 @@
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
+
+from odoo import api, models
+
+
+class MakeInvoice(models.TransientModel):
+    _inherit = 'repair.order.make_invoice'
+
+    @api.multi
+    def make_invoices(self):
+        if self._context.get('active_model') == 'rma.order.line':
+            rma_lines = self.env['rma.order.line'].browse(
+                self._context.get('active_ids'))
+            self = self.with_context(
+                active_ids=rma_lines.mapped('repair_ids').ids)
+        return super().make_invoices()


### PR DESCRIPTION
Currently rmas with delivery policy is based on repair quantity  cannot be delivered until the the repair order is paid. That is too restrictive, better just to inform in the RMA about there's some qty to pay instead of restricting.

TODO:
- [x] qty delivered should not depends on qty_to_pay just on qty_repaired
- [x] allow to invoice from the RMA instead of going to the repair order

cc @AdriaGForgeFlow 
