### PR TITLE
[FIX]inv.number for inv.name

### DIFF
--- a/rma_sale/models/sale_order_line.py
+++ b/rma_sale/models/sale_order_line.py
@@ -44,12 +44,7 @@ class SaleOrderLine(models.Model):
                             "SO:%s | INV: %s, | PART:%s | QTY:%s"
                             % (
                                 sale.order_id.name,
-                                " ".join(
-                                    str(x)
-                                    for x in [
-                                        inv.number for inv in sale.order_id.invoice_ids
-                                    ]
-                                ),
+                                " ".join(str(x) for x in [inv.name for inv in sale.order_id.invoice_ids]),
                                 sale.product_id.name,
                                 sale.product_uom_qty,
                             ),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Throwing error when try to select 'Originating Sales Order Line'.

Current behavior before PR:
Raise following errors:
RecursionError: maximum recursion depth exceeded while calling a Python object
UnicodeError: unable to convert <odoo.tools.func.lazy object at 0x7f3af88aa240>

Desired behavior after PR is merged:
Select 'Originating Sales Order Line' normally.