### PR TITLE
[FIX] ValueError: External ID not found in the system: account.res_partner_action_supplier

### DIFF
--- a/rma/views/rma_menu.xml
+++ b/rma/views/rma_menu.xml
@@ -142,7 +142,7 @@
         id="rma_res_partner_menu_suppliers"
         name="Suppliers"
         parent="rma.menu_rma_config_partners"
-        action="account.res_partner_action_supplier"
+        action="base.action_partner_supplier_form"
         sequence="60"
     />
 </odoo>


### PR DESCRIPTION
Issue:
--------

- Install rma module in plain database. It throws

> ValueError: External ID not found in the system: account.res_partner_action_supplier

This PR will fix value error. 