### PR TITLE
[14.0][FIX] rma_sale: set fiscal position in SO

### DIFF
--- a/rma_sale/wizards/rma_order_line_make_sale_order.py
+++ b/rma_sale/wizards/rma_order_line_make_sale_order.py
@@ -72,11 +72,21 @@ class RmaLineMakeSaleOrder(models.TransientModel):
         if not self.partner_id:
             raise exceptions.Warning(_("Enter a customer."))
         customer = self.partner_id
+        auto = self.env["account.fiscal.position"].search(
+            [("auto_apply", "=", True), ("country_id", "=", customer.country_id.id)],
+            limit=1,
+        )
+        fiscal_position = False
+        if customer.property_account_position_id:
+            fiscal_position = customer.property_account_position_id
+        elif auto:
+            fiscal_position = auto
         data = {
             "origin": line.name,
             "partner_id": customer.id,
             "warehouse_id": line.out_warehouse_id.id,
             "company_id": line.company_id.id,
+            "fiscal_position_id": fiscal_position.id if fiscal_position else False,
         }
 
         return data


### PR DESCRIPTION
The fiscal position in the sale order will be set using this criteria:

- If the partner has a fiscal position set.
- If it exists an "auto_apply" fiscal position that matches the partner country. 
Issue link: https://github.com/ForgeFlow/stock-rma/issues/165
cc @AaronHForgeFlow 