### PR TITLE
[14.0][FIX] rma_account: change account in credit notes

### DIFF
--- a/rma_account/wizards/rma_refund.py
+++ b/rma_account/wizards/rma_refund.py
@@ -108,9 +108,9 @@ class RmaRefund(models.TransientModel):
     def prepare_refund_line(self, item):
         accounts = item.product.product_tmpl_id._get_product_accounts()
         if item.line_id.type == "customer":
-            account = accounts["stock_output"]
+            account = accounts["income"]
         else:
-            account = accounts["stock_input"]
+            account = accounts["expense"]
         if not account:
             raise ValidationError(_("Accounts are not configured for this product."))
 


### PR DESCRIPTION
Wrong account in credit notes for customer RMAS. It is using stock output (interim) account by default. It should be sales.
For supplier RMAS it is changed the account to Expenses.
Issue: https://github.com/ForgeFlow/stock-rma/issues/166
cc @AaronHForgeFlow 