### PR TITLE
[rma_account][imp] do not force the refund invoice number to be the RMA number.

### DIFF
--- a/rma_account/wizards/rma_refund.py
+++ b/rma_account/wizards/rma_refund.py
@@ -139,7 +139,6 @@ class RmaRefund(models.TransientModel):
                 [("type", "=", "purchase")], limit=1
             )
         values = {
-            "name": rma_line.rma_id.name or rma_line.name,
             "payment_reference": rma_line.rma_id.name or rma_line.name,
             "invoice_origin": rma_line.rma_id.name or rma_line.name,
             "ref": False,


### PR DESCRIPTION
This would cause duplicates in the numbering of journal entries. Was a bad idea in the first place.

cc @MateuGForgeFlow @ForgeFlow