### PR TITLE
[14.0][IMP] rma_filter_lot: onchange returned by domain should use ids

### DIFF
--- a/rma_filter_lot/README.rst
+++ b/rma_filter_lot/README.rst
@@ -1,0 +1,37 @@
+==============
+RMA Filter Lot
+==============
+
+Filter RMA lots in customer RMA to only allow lots sent to customer.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/ForgeFlow/stock-rma/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed
+`feedback <https://github.com/ForgeFlow/stock-rma/issues/new?body=module:%20rma%0Aversion:%2013.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Do not contact contributors directly about support or help with technical issues.
+
+Credits
+=======
+
+Authors
+~~~~~~~
+
+* ForgeFlow S.L.
+
+Contributors
+~~~~~~~~~~~~
+
+* Mateu Griful <mateu.griful@forgeflow.com>
+* Lois Rilo <lois.rilo@forgeflow.com>
+
+Maintainers
+~~~~~~~~~~~
+
+This module is maintained by the ForgeFlow.
+
+This module is part of the `ForgeFlow/stock-rma <https://github.com/ForgeFlow/stock-rma/tree/13.0/rma>`_ project on GitHub.
+

--- a/rma_filter_lot/models/rma_order_line.py
+++ b/rma_filter_lot/models/rma_order_line.py
@@ -9,10 +9,9 @@ class RmaOrderLine(models.Model):
     _inherit = "rma.order.line"
 
     lot_id = fields.Many2one(
-        comodel_name="stock.production.lot",
-        domain="[('id', 'in', valid_lots_ids)]",
+        domain="[('id', 'in', valid_lot_ids)]",
     )
-    valid_lots_ids = fields.One2many(
+    valid_lot_ids = fields.One2many(
         comodel_name="stock.production.lot",
         compute="_compute_domain_lot_ids",
     )
@@ -40,8 +39,9 @@ class RmaOrderLine(models.Model):
                         valid_ids |= quant.lot_id
                 if valid_ids:
                     lots = valid_ids
-            rec.valid_lots_ids = lots
+            rec.valid_lot_ids = lots
 
     def _onchange_product_id(self):
         super()._onchange_product_id()
-        return {"domain": {"lot_id": [("id", "in", self.valid_lots_ids)]}}
+        # Override domain added in base `rma` module.
+        return {"domain": {"lot_id": [("id", "in", self.valid_lot_ids.ids)]}}

--- a/rma_filter_lot/views/rma_order_view.xml
+++ b/rma_filter_lot/views/rma_order_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="rma.view_rma_line_form" />
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
-                <field name="valid_lots_ids" invisible="1" />
+                <field name="valid_lot_ids" invisible="1" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
* onchange returned by domain should use ids
* rename field to `valid_lot_ids`.
* add small readme

@ForgeFlow