### PR TITLE
[14.0][rma][fix] rma: when using 2 step receipt or delivery, don't count double

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -75,6 +75,11 @@ class RmaOrderLine(models.Model):
             for move in rec.move_ids.filtered(
                 lambda m: m.state in states and op(m.location_id.usage, rec.type)
             ):
+                # If the move is part of a chain don't count it
+                if direction == "out" and move.move_orig_ids:
+                    continue
+                elif direction == "in" and move.move_dest_ids:
+                    continue
                 qty += product_obj._compute_quantity(move.product_uom_qty, rec.uom_id)
             return qty
 

--- a/rma/models/stock.py
+++ b/rma/models/stock.py
@@ -44,3 +44,19 @@ class StockMove(models.Model):
             if move.rma_line_id:
                 move.partner_id = move.rma_line_id.partner_id.id or False
         return res
+
+    @api.model
+    def _get_first_usage(self):
+        if self.move_orig_ids:
+            # We assume here that all origin moves come from the same place
+            return self.move_orig_ids[0]._get_first_usage()
+        else:
+            return self.location_id.usage
+
+    @api.model
+    def _get_last_usage(self):
+        if self.move_dest_ids:
+            # We assume here that all origin moves come from the same place
+            return self.move_dest_ids[0]._get_last_usage()
+        else:
+            return self.location_dest_id.usage


### PR DESCRIPTION
In the scenario where we use a 2 or 3 step receipts or pickings we want to make sure that we correctly count and classify the pickings.

