### PR TITLE
[15.0][FIX] rma: compute out_shipment_count correctly. Add test cases

### DIFF
--- a/rma/models/rma_order.py
+++ b/rma/models/rma_order.py
@@ -30,7 +30,7 @@ class RmaOrder(models.Model):
             pickings = self.env["stock.picking"]
             for line in rec.rma_line_ids:
                 pickings |= line._get_out_pickings()
-            rec.in_shipment_count = len(pickings)
+            rec.out_shipment_count = len(pickings)
 
     def _compute_supplier_line_count(self):
         self.supplier_line_count = len(


### PR DESCRIPTION
Forward port of https://github.com/ForgeFlow/stock-rma/pull/218.

cc @JordiBForgeFlow @ChrisOForgeFlow 