### PR TITLE
[14] Add missing fields in rma line editable tree in rma group

### DIFF
--- a/rma/views/rma_order_view.xml
+++ b/rma/views/rma_order_view.xml
@@ -167,6 +167,9 @@
                                 <field name="out_warehouse_id" invisible="True" />
                                 <field name="customer_to_supplier" invisible="True" />
                                 <field name="supplier_address_id" invisible="True" />
+                                <field name="receipt_policy" invisible="True" />
+                                <field name="delivery_policy" invisible="True" />
+                                <field name="delivery_address_id" invisible="True" />
                                 <field name="product_qty" />
                                 <field name="price_unit" />
                             </tree>


### PR DESCRIPTION
Without these fields,operation_id onchange won't update the fields so if we add rma line from a rma.order group, the missing fields won't be consistent with the chosen operation_id

Step to reproduce : 
Install rma module
Create a rma group with 1 rma line with operation "RPL-C".
The created rma line has no Receipt/delivery policy