### PR TITLE
[14] Remove useless value in prepare method

### DIFF
--- a/rma/wizards/rma_make_picking.py
+++ b/rma/wizards/rma_make_picking.py
@@ -22,7 +22,6 @@ class RmaMakePicking(models.TransientModel):
             "qty_to_deliver": line.qty_to_deliver,
             "line_id": line.id,
             "rma_id": line.rma_id and line.rma_id.id or False,
-            "wiz_id": self.env.context["active_id"],
         }
         return values
 


### PR DESCRIPTION
Hello,
Small fix, here the wiz_id contain the id on a rma.order.line, which make no sense.
It does not really have any impact since it is not used by Odoo but it is a bit disturbing !