### PR TITLE
[12.0][FIX/IMP] Make "RMA Operation" settings company dependent

### DIFF
--- a/rma/__manifest__.py
+++ b/rma/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'RMA (Return Merchandise Authorization)',
-    'version': '12.0.2.3.0',
+    'version': '12.0.3.0.0',
     'license': 'LGPL-3',
     'category': 'RMA',
     'summary': 'Introduces the return merchandise authorization (RMA) process '

--- a/rma/migrations/12.0.3.0.0/post-migration.py
+++ b/rma/migrations/12.0.3.0.0/post-migration.py
@@ -1,0 +1,101 @@
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def set_rma_customer_operation_property(cr):
+    """
+    """
+    cr.execute(
+        """
+        WITH rma_customer_operation_id_field AS (
+            SELECT id FROM ir_model_fields WHERE model='product.template' AND name='rma_customer_operation_id'
+        )
+        INSERT INTO ir_property(name, type, fields_id, company_id, res_id, value_reference)
+        SELECT 'rma_customer_operation_id', 'many2one', rco.id, ro.company_id, CONCAT('product.template,', t.id), CONCAT('rma.operation,', ro.id)
+        FROM product_template t JOIN rma_operation ro ON t.rma_customer_operation_id = ro.id
+        , rma_customer_operation_id_field rco
+        WHERE ro.company_id IS NOT NULL
+              AND NOT EXISTS(SELECT 1
+                             FROM ir_property
+                             WHERE fields_id=rco.id
+                                AND company_id=ro.company_id
+                                AND res_id=CONCAT('product.template,', t.id))
+    """)
+    _logger.info("Added %s rma_customer_operation_id_field product properties", cr.rowcount)
+
+
+def set_rma_supplier_operation_property(cr):
+    """
+    """
+    cr.execute(
+        """
+        WITH rma_supplier_operation_id_field AS (
+            SELECT id FROM ir_model_fields WHERE model='product.template' AND name='rma_supplier_operation_id'
+        )
+        INSERT INTO ir_property(name, type, fields_id, company_id, res_id, value_reference)
+        SELECT 'rma_supplier_operation_id', 'many2one', rco.id, ro.company_id, CONCAT('product.template,', t.id), CONCAT('rma.operation,', ro.id)
+        FROM product_template t JOIN rma_operation ro ON t.rma_supplier_operation_id = ro.id
+        , rma_supplier_operation_id_field rco
+        WHERE ro.company_id IS NOT NULL
+              AND NOT EXISTS(SELECT 1
+                             FROM ir_property
+                             WHERE fields_id=rco.id
+                                AND company_id=ro.company_id
+                                AND res_id=CONCAT('product.template,', t.id))
+    """)
+    _logger.info("Added %s rma_supplier_operation_id_field product properties", cr.rowcount)
+
+
+def set_rma_customer_operation_category_property(cr):
+    """
+    """
+    cr.execute(
+        """
+        WITH rma_customer_operation_id_field AS (
+            SELECT id FROM ir_model_fields WHERE model='product.category' AND name='rma_customer_operation_id'
+        )
+        INSERT INTO ir_property(name, type, fields_id, company_id, res_id, value_reference)
+        SELECT 'rma_customer_operation_id', 'many2one', rco.id, ro.company_id, CONCAT('product.category,', pc.id), CONCAT('rma.operation,', ro.id)
+        FROM product_category pc JOIN rma_operation ro ON pc.rma_customer_operation_id = ro.id
+        , rma_customer_operation_id_field rco
+        WHERE ro.company_id IS NOT NULL
+              AND NOT EXISTS(SELECT 1
+                             FROM ir_property
+                             WHERE fields_id=rco.id
+                                AND company_id=ro.company_id
+                                AND res_id=CONCAT('product.category,', pc.id))
+    """)
+    _logger.info("Added %s rma_customer_operation_id_field product category properties", cr.rowcount)
+
+
+def set_rma_supplier_operation_category_property(cr):
+    """
+    """
+    cr.execute(
+        """
+        WITH rma_supplier_operation_id_field AS (
+            SELECT id FROM ir_model_fields WHERE model='product.category' AND name='rma_supplier_operation_id'
+        )
+        INSERT INTO ir_property(name, type, fields_id, company_id, res_id, value_reference)
+        SELECT 'rma_supplier_operation_id', 'many2one', rco.id, ro.company_id, CONCAT('product.category,', pc.id), CONCAT('rma.operation,', ro.id)
+        FROM product_category pc JOIN rma_operation ro ON pc.rma_supplier_operation_id = ro.id
+        , rma_supplier_operation_id_field rco
+        WHERE ro.company_id IS NOT NULL
+              AND NOT EXISTS(SELECT 1
+                             FROM ir_property
+                             WHERE fields_id=rco.id
+                                AND company_id=ro.company_id
+                                AND res_id=CONCAT('product.category,', pc.id))
+    """)
+    _logger.info("Added %s rma_supplier_operation_id_field product category properties", cr.rowcount)
+
+
+def migrate(cr, version=None):
+    if not version:
+        return
+    set_rma_customer_operation_property(cr)
+    set_rma_supplier_operation_property(cr)
+    set_rma_customer_operation_category_property(cr)
+    set_rma_supplier_operation_category_property(cr)

--- a/rma/models/product.py
+++ b/rma/models/product.py
@@ -8,8 +8,10 @@ class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
     rma_customer_operation_id = fields.Many2one(
+        company_dependent=True,
         comodel_name="rma.operation", string="Default RMA Customer Operation")
     rma_supplier_operation_id = fields.Many2one(
+        company_dependent=True,
         comodel_name="rma.operation", string="Default RMA Supplier Operation")
     rma_approval_policy = fields.Selection(
         related="categ_id.rma_approval_policy", readonly=True)

--- a/rma/models/product_category.py
+++ b/rma/models/product_category.py
@@ -16,6 +16,8 @@ class ProductCategory(models.Model):
              "* Two steps: A RMA containing a product within a category with "
              "this policy will request the RMA manager approval.")
     rma_customer_operation_id = fields.Many2one(
+        company_dependent=True,
         comodel_name="rma.operation", string="Default RMA Customer Operation")
     rma_supplier_operation_id = fields.Many2one(
+        company_dependent=True,
         comodel_name="rma.operation", string="Default RMA Supplier Operation")

--- a/rma/tests/__init__.py
+++ b/rma/tests/__init__.py
@@ -2,3 +2,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
 from . import test_rma
+from . import test_migrations

--- a/rma/tests/test_migrations.py
+++ b/rma/tests/test_migrations.py
@@ -1,0 +1,64 @@
+import imp
+import os
+
+from odoo.modules import get_module_resource
+from odoo.tests.common import TransactionCase
+from odoo.tools import file_open
+
+
+class TestMigrations(TransactionCase):
+    def test_migration_12_0_3_0_0(self):
+        """Test the migration scripts to 12.0.3.0.0 """
+
+        # Recreate pre-migration condition
+        self.env.cr.execute("""
+            ALTER TABLE product_template
+            ADD COLUMN IF NOT EXISTS rma_customer_operation_id INTEGER """)
+        self.env.cr.execute("""
+            ALTER TABLE product_template
+            ADD COLUMN IF NOT EXISTS rma_supplier_operation_id INTEGER """)
+        self.env.cr.execute("""
+            ALTER TABLE product_category
+            ADD COLUMN IF NOT EXISTS rma_customer_operation_id INTEGER """)
+        self.env.cr.execute("""
+            ALTER TABLE product_category
+            ADD COLUMN IF NOT EXISTS rma_supplier_operation_id INTEGER """)
+
+        rma_operation = self.env["rma.operation"].search([], limit=1)
+        self.env.cr.execute(
+            "UPDATE product_template SET rma_customer_operation_id = %d" % rma_operation.id
+        )
+        self.env.cr.execute(
+            "UPDATE product_template SET rma_supplier_operation_id = %d" % rma_operation.id
+        )
+        self.env.cr.execute(
+            "UPDATE product_category SET rma_customer_operation_id = %d" % rma_operation.id
+        )
+        self.env.cr.execute(
+            "UPDATE product_category SET rma_supplier_operation_id = %d" % rma_operation.id
+        )
+
+        # Properties are not set
+        product = self.env.ref("product.product_product_5")
+        product_tmpl = product.product_tmpl_id
+        product_categ = product.categ_id
+        self.assertFalse(product_tmpl.rma_customer_operation_id)
+        self.assertFalse(product_tmpl.rma_supplier_operation_id)
+        self.assertFalse(product_categ.rma_customer_operation_id)
+        self.assertFalse(product_categ.rma_supplier_operation_id)
+
+        # Run the migration script
+        pyfile = get_module_resource(
+            "rma", "migrations", "12.0.3.0.0", "post-migration.py")
+        name, ext = os.path.splitext(os.path.basename(pyfile))
+        fp, pathname = file_open(pyfile, pathinfo=True)
+        mod = imp.load_module(name, fp, pathname, (".py", "r", imp.PY_SOURCE))
+        mod.migrate(self.env.cr, "12.0.2.3.0")
+
+        # Properties are set
+        product_tmpl.refresh()
+        product_categ.refresh()
+        self.assertEqual(product_tmpl.rma_customer_operation_id, rma_operation)
+        self.assertEqual(product_tmpl.rma_supplier_operation_id, rma_operation)
+        self.assertEqual(product_categ.rma_customer_operation_id, rma_operation)
+        self.assertEqual(product_categ.rma_supplier_operation_id, rma_operation)

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -608,3 +608,40 @@ class TestRma(common.SavepointCase):
             line.action_rma_done()
             self.assertEquals(line.state, 'done',
                               "Wrong State")
+
+    def test_05_rma_order_line(self):
+        """ Property rma_customer_operation_id on product or product category
+        correctly handled inside _onchange_product_id()
+        """
+        rma_operation = self.env["rma.operation"].search([], limit=1)
+        self.assertTrue(rma_operation)
+
+        # Case of product template
+        self.rma_customer_id.rma_line_ids\
+            .mapped("product_id")\
+            .write({"rma_customer_operation_id": rma_operation.id})
+        for line in self.rma_customer_id.rma_line_ids:
+            data = {'product_id': line.product_id.id}
+            new_line = self.rma_line.new(data)
+            self.assertFalse(new_line.operation_id)
+            self.assertTrue(new_line.product_id.rma_customer_operation_id)
+            self.assertFalse(new_line.product_id.categ_id.rma_customer_operation_id)
+            new_line._onchange_product_id()
+            self.assertEqual(new_line.operation_id, rma_operation)
+
+        # Case of product category
+        self.rma_customer_id.rma_line_ids\
+            .mapped("product_id")\
+            .write({"rma_customer_operation_id": False})
+        self.rma_customer_id.rma_line_ids \
+            .mapped("product_id.categ_id") \
+            .write({"rma_customer_operation_id": rma_operation.id})
+
+        for line in self.rma_customer_id.rma_line_ids:
+            data = {'product_id': line.product_id.id}
+            new_line = self.rma_line.new(data)
+            self.assertFalse(new_line.operation_id)
+            self.assertFalse(new_line.product_id.rma_customer_operation_id)
+            self.assertTrue(new_line.product_id.categ_id.rma_customer_operation_id)
+            new_line._onchange_product_id()
+            self.assertEqual(new_line.operation_id, rma_operation)


### PR DESCRIPTION
@ForgeFlow team

**Issue**
Attempting to view a `product.template` results in a read error when a `rma.operation` with a company other than the current user's company has been assigned to the product:
![image](https://user-images.githubusercontent.com/7657635/167415512-85855b61-ddd0-4964-bf6b-86d1f5cdc70e.png)


**Steps to Reproduce**
- Create a RMA Operation and set the Company property to the current user's company.
- Add the RMA Operation to a product template.
- Switch companies.
- Attempt to view the same product template.

**Proposed solution**
- [x] Make fields `rma_customer_operation_id` and `rma_supplier_operation_id` company dependent
- [x] Migration scripts for existing settings