### PR TITLE
[14][FIX] count produced products going to customer as out pickings

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -64,7 +64,7 @@ class RmaOrderLine(models.Model):
         for move in self.move_ids:
             first_usage = move._get_first_usage()
             last_usage = move._get_last_usage()
-            if first_usage == "internal" and last_usage != "internal":
+            if first_usage in ("internal", "production") and last_usage != "internal":
                 pickings |= move.picking_id
             elif last_usage == "customer" and first_usage == "supplier":
                 pickings |= move.picking_id


### PR DESCRIPTION
Fix the case where you produce a product and then send it to the customer. It should count as an outgoing picking in that case.

@LoisRForgeFlow @JordiBForgeFlow 