### PR TITLE
[15.0][FIX] rma: prevent against warehouse mismatch or missing rules

### DIFF
--- a/rma/models/procurement_group.py
+++ b/rma/models/procurement_group.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2017-22 ForgeFlow S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ProcurementGroup(models.Model):
@@ -13,3 +14,24 @@ class ProcurementGroup(models.Model):
     rma_line_id = fields.Many2one(
         comodel_name="rma.order.line", string="RMA line", ondelete="set null"
     )
+
+    @api.model
+    def _get_rule(self, product_id, location_id, values):
+        """Ensure that the selected rule is from the configured route"""
+        res = super()._get_rule(product_id, location_id, values)
+        force_rule_ids = self.env.context.get("rma_force_rule_ids")
+        if force_rule_ids:
+            if res and res.id not in force_rule_ids:
+                raise ValidationError(
+                    _(
+                        "No rule found in this RMA's configured route for product "
+                        "%(product)s and location %(location)s"
+                    )
+                    % {
+                        "product": product_id.default_code or product_id.name,
+                        "location": location_id.complete_name,
+                    }
+                )
+            # Don't enforce rules on any chained moves
+            force_rule_ids.clear()
+        return res


### PR DESCRIPTION
When creating pickings, ensure that the applied stock rule was taken from
the operation's routes. Otherwise, the default procurement rules for a
warehouse may kick in, creating incoming customer goods not from the customer
location but from the resupply warehouse.