### PR TITLE
[FIX]rma: remove test_rma dependency to Account

### DIFF
--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -48,7 +48,6 @@ class TestRma(common.SavepointCase):
         cls.g_rma_customer_user = cls.env.ref("rma.group_rma_customer_user")
         cls.g_rma_manager = cls.env.ref("rma.group_rma_manager")
         cls.g_rma_supplier_user = cls.env.ref("rma.group_rma_supplier_user")
-        cls.g_account_manager = cls.env.ref("account.group_account_manager")
         cls.g_stock_user = cls.env.ref("stock.group_stock_user")
         cls.g_stock_manager = cls.env.ref("stock.group_stock_manager")
 
@@ -59,7 +58,7 @@ class TestRma(common.SavepointCase):
         )
         cls.rma_manager_user = cls._create_user(
             "rma manager",
-            [cls.g_stock_manager, cls.g_rma_manager, cls.g_account_manager],
+            [cls.g_stock_manager, cls.g_rma_manager],
             cls.company,
         )
         # Customer RMA:


### PR DESCRIPTION
Removed test_rma.py dependency to Account, 
to do this I have removed the account declarations for the manager user account in the test, and moved the old declaration of rma_manager_user to rma_account_unreconciled/tests, because this tests need the account declaration.

@ForgeFlow