### PR TITLE
[14.0] Hide smart button when empty on rma.line

### DIFF
--- a/rma/views/rma_order_line_view.xml
+++ b/rma/views/rma_order_line_view.xml
@@ -100,6 +100,7 @@
                                 name="action_view_in_shipments"
                                 class="oe_stat_button"
                                 icon="fa-truck"
+                                attrs="{'invisible': [('in_shipment_count', '=', 0)]}"
                                 groups="stock.group_stock_user"
                             >
                                 <field
@@ -113,6 +114,7 @@
                                 name="action_view_out_shipments"
                                 class="oe_stat_button"
                                 icon="fa-truck"
+                                attrs="{'invisible': [('out_shipment_count', '=', 0)]}"
                                 groups="stock.group_stock_user"
                             >
                                 <field
@@ -133,6 +135,7 @@
                                 class="oe_stat_button"
                                 icon="fa-link"
                                 groups="stock.group_stock_user"
+                                attrs="{'invisible': [('rma_line_count', '=', 0)]}"
                             >
                                 <field
                                     name="rma_line_count"

--- a/rma_account/views/rma_order_line_view.xml
+++ b/rma_account/views/rma_order_line_view.xml
@@ -30,6 +30,7 @@
                     name="action_view_invoice"
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
+                    attrs="{'invisible': [('account_move_line_id', '=', False)]}"
                     string="Origin Inv"
                 >
                 </button>
@@ -38,6 +39,7 @@
                     name="action_view_refunds"
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
+                    attrs="{'invisible': [('refund_count', '=', 0)]}"
                     groups="account.group_account_invoice"
                 >
                         <field name="refund_count" widget="statinfo" string="Refunds" />

--- a/rma_sale/models/rma_order_line.py
+++ b/rma_sale/models/rma_order_line.py
@@ -203,6 +203,13 @@ class RmaOrderLine(models.Model):
         result["domain"] = [("id", "in", order_ids)]
         return result
 
+    def action_view_origin_sale_order(self):
+        action = self.env.ref("sale.action_orders_salesteams")
+        result = action.sudo().read()[0]
+        order_ids = self.sale_id.ids
+        result["domain"] = [("id", "in", order_ids)]
+        return result
+
     def _get_rma_sold_qty(self):
         self.ensure_one()
         qty = 0.0

--- a/rma_sale/views/rma_order_line_view.xml
+++ b/rma_sale/views/rma_order_line_view.xml
@@ -7,11 +7,21 @@
             <field name="inherit_id" ref="rma.view_rma_line_form" />
             <field name="arch" type="xml">
                 <div name='button_box' position="inside">
+                <button
+                    type="object"
+                    name="action_view_origin_sale_order"
+                    class="oe_stat_button"
+                    icon="fa-strikethrough"
+                    attrs="{'invisible': [('sale_id', '=', False)]}"
+                    string="Origin Sale Order"
+                >
+                </button>
                     <button
                     type="object"
                     name="action_view_sale_order"
                     class="oe_stat_button"
                     icon="fa-strikethrough"
+                    attrs="{'invisible': [('sales_count', '=', 0)]}"
                     groups="sales_team.group_sale_salesman_all_leads"
                 >
                             <field
@@ -22,6 +32,7 @@
                     </button>
                 </div>
                 <group name="main_info" position="inside">
+                    <field name="sale_id" invisible="1" />
                     <field
                     name="sale_line_id"
                     context="{'rma': True}"
@@ -37,12 +48,6 @@
                 </group>
                 <field name="delivery_policy" position="after">
                     <field name="sale_policy" />
-                </field>
-                <field name="origin" position="after">
-                    <field
-                    name="sale_id"
-                    attrs="{'invisible': [('sale_line_id', '=', False)]}"
-                />
                 </field>
                 <notebook position="inside">
                     <page name="sale" string="Sale Lines">


### PR DESCRIPTION
Hello,

I am looking to install these RMA modules for a customer, and one of the main issue I meet, is that there are a lot of useless fields, button, smart button, etc, for the case of this customer.
I guess some feature could be in separated modules, although it is probably a change to do during migration of those modules (and maybe not an easy one), but another way to simplify the view is to hide every thing that is not usefull for the current rma line.

So here, I hide all smart button that are empty, for a start.

If you are ok with the idea, I'll do the same for other stuff. The goal beeing to have a simpler view depending on the option chosen (operation) and the action that have been done.
Example, I have a rma line with "Receipts Policy" = "Not required". I still see the "Create Incoming Shipment" button (which give an error if clicked). I also see information about qty to receive, qty received, etc. 
I guess in this case we should hide all this information.

I'd love a feedback on the idea and if positive I will do other PR around this ! @LoisRForgeFlow 