### PR TITLE
[14.0][rma] internal transfer

### DIFF
--- a/rma/views/rma_order_line_view.xml
+++ b/rma/views/rma_order_line_view.xml
@@ -111,6 +111,20 @@
                             </button>
                             <button
                                 type="object"
+                                name="action_view_int_pickings"
+                                class="oe_stat_button"
+                                icon="fa-truck"
+                                groups="stock.group_stock_user"
+                                attrs="{'invisible': [('int_picking_count', '=', 0)]}"
+                            >
+                                <field
+                                    name="int_picking_count"
+                                    widget="statinfo"
+                                    string="Internal Transfers"
+                                />
+                            </button>
+                            <button
+                                type="object"
                                 name="action_view_out_shipments"
                                 class="oe_stat_button"
                                 icon="fa-truck"
@@ -123,12 +137,6 @@
                                     string="Deliveries"
                                 />
                             </button>
-                            <!--Move this button to rma_account-->
-                            <!--<button type="object"  name="action_view_invoice"
-                                    class="oe_stat_button"
-                                    icon="fa-pencil-square-o"
-                                    string="Origin Inv">
-                            </button>-->
                             <button
                                 type="object"
                                 name="action_view_rma_lines"

--- a/rma/views/rma_order_view.xml
+++ b/rma/views/rma_order_view.xml
@@ -203,6 +203,7 @@
                             class="oe_stat_button"
                             icon="fa-truck"
                             groups="stock.group_stock_user"
+                            attrs="{'invisible': [('in_shipment_count', '=', 0)]}"
                         >
                         <field
                                 name="in_shipment_count"
@@ -230,6 +231,7 @@
                             class="oe_stat_button"
                             icon="fa-truck"
                             groups="stock.group_stock_user"
+                            attrs="{'invisible': [('out_shipment_count', '=', 0)]}"
                         >
                         <field
                                 name="out_shipment_count"

--- a/rma/views/rma_order_view.xml
+++ b/rma/views/rma_order_view.xml
@@ -212,6 +212,20 @@
                     </button>
                     <button
                             type="object"
+                            name="action_view_int_pickings"
+                            class="oe_stat_button"
+                            icon="fa-truck"
+                            groups="stock.group_stock_user"
+                            attrs="{'invisible': [('int_picking_count', '=', 0)]}"
+                        >
+                        <field
+                                name="int_picking_count"
+                                widget="statinfo"
+                                string="Internal Transfers"
+                            />
+                    </button>
+                    <button
+                            type="object"
                             name="action_view_out_shipments"
                             class="oe_stat_button"
                             icon="fa-truck"

--- a/rma_account/views/rma_order_view.xml
+++ b/rma_account/views/rma_order_view.xml
@@ -12,6 +12,7 @@
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
                     groups="account.group_account_invoice"
+                    attrs="{'invisible': [('invoice_refund_count', '=', 0)]}"
                 >
                     <field
                         name="invoice_refund_count"
@@ -25,6 +26,7 @@
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
                     groups="account.group_account_invoice"
+                    attrs="{'invisible': [('invoice_count', '=', 0)]}"
                 >
                     <field name="invoice_count" widget="statinfo" string="Origin Inv" />
                 </button>
@@ -47,6 +49,7 @@
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
                     groups="account.group_account_invoice"
+                    attrs="{'invisible': [('invoice_refund_count', '=', 0)]}"
                 >
                      <field
                         name="invoice_refund_count"
@@ -60,6 +63,7 @@
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
                     groups="account.group_account_invoice"
+                    attrs="{'invisible': [('invoice_count', '=', 0)]}"
                 >
                      <field
                         name="invoice_count"
@@ -68,12 +72,6 @@
                     />
                  </button>
             </button>
-            <!--
-            <xpath expr="//field[@name='rma_line_ids']/tree"
-                   position="inside">
-                <field name="account_move_line_id" invisible="True"/>
-            </xpath>
-            -->
         </field>
     </record>
 </odoo>

--- a/rma_sale/views/rma_order_view.xml
+++ b/rma_sale/views/rma_order_view.xml
@@ -12,6 +12,7 @@
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
                     groups="sales_team.group_sale_salesman"
+                    attrs="{'invisible': [('sale_count', '=', 0)]}"
                 >
                         <field name="sale_count" widget="statinfo" string="Origin SO" />
                     </button>


### PR DESCRIPTION
Adds a smart button to display internal transfers. It is necessary after https://github.com/ForgeFlow/stock-rma/pull/277 is introduced.