### PR TITLE
[14.0][IMP] Make rma order line view cleaner for user

### DIFF
--- a/rma/views/rma_order_line_view.xml
+++ b/rma/views/rma_order_line_view.xml
@@ -217,12 +217,18 @@
                         <notebook>
                             <page name="quantities" string="Quantities">
                                 <group name="quantities" col="4" string="Quantities">
-                                    <group name="receive">
+                                    <group
+                                        name="receive"
+                                        attrs="{'invisible': [('receipt_policy', '=', 'no')]}"
+                                    >
                                         <field name="qty_to_receive" />
                                         <field name="qty_incoming" />
                                         <field name="qty_received" />
                                     </group>
-                                    <group name="deliver">
+                                    <group
+                                        name="deliver"
+                                        attrs="{'invisible': [('delivery_policy', '=', 'no')]}"
+                                    >
                                         <field name="qty_to_deliver" />
                                         <field name="qty_outgoing" />
                                         <field name="qty_delivered" />
@@ -278,7 +284,11 @@
                                     />
                                 </group>
                             </page>
-                            <page name="stock" string="Stock Moves">
+                            <page
+                                name="stock"
+                                string="Stock Moves"
+                                attrs="{'invisible': [('move_ids', '=', [])]}"
+                            >
                                 <field name="move_ids" nolabel="1" readonly="1" />
                             </page>
                             <page name="other" string="Other Info">

--- a/rma/wizards/rma_make_picking_view.xml
+++ b/rma/wizards/rma_make_picking_view.xml
@@ -108,26 +108,26 @@
                     name="%(action_rma_picking_in)d"
                     string="Create Incoming Shipment"
                     class="oe_highlight"
-                    attrs="{'invisible':['|', ('qty_to_receive', '=', 0), ('state', '!=', 'approved')]}"
+                    attrs="{'invisible':['|', '|', ('qty_to_receive', '=', 0), ('state', '!=', 'approved'), ('receipt_policy', '=', 'no')]}"
                     type="action"
                 />
                 <button
                     name="%(action_rma_picking_in)d"
                     string="Create Incoming Shipment"
-                    attrs="{'invisible':['|', ('qty_to_receive', '!=', 0), ('state', '!=', 'approved')]}"
+                    attrs="{'invisible':['|', '|', ('qty_to_receive', '!=', 0), ('state', '!=', 'approved'), ('receipt_policy', '=', 'no')]}"
                     type="action"
                 />
                 <button
                     name="%(action_rma_picking_out)d"
                     string="Create Delivery"
                     class="oe_highlight"
-                    attrs="{'invisible':['|', ('qty_to_deliver', '=', 0), ('state', '!=', 'approved')]}"
+                    attrs="{'invisible':['|', '|', ('qty_to_deliver', '=', 0), ('state', '!=', 'approved'), ('delivery_policy', '=', 'no')]}"
                     type="action"
                 />
                 <button
                     name="%(action_rma_picking_out)d"
                     string="Create Delivery"
-                    attrs="{'invisible':['|', ('qty_to_deliver', '!=', 0), ('state', '!=', 'approved')]}"
+                    attrs="{'invisible':['|', '|', ('qty_to_deliver', '!=', 0), ('state', '!=', 'approved'), ('delivery_policy', '=', 'no')]}"
                     type="action"
                 />
             </header>

--- a/rma_account/views/rma_order_line_view.xml
+++ b/rma_account/views/rma_order_line_view.xml
@@ -58,7 +58,11 @@
                 <field name="refund_policy" />
             </field>
             <page name="stock" position="after">
-                <page name="refunds" string="Refunds">
+                <page
+                    name="refunds"
+                    string="Refunds"
+                    attrs="{'invisible': [('refund_line_ids', '=', [])]}"
+                >
                     <field name="refund_line_ids" nolabel="1" />
                 </page>
             </page>
@@ -69,7 +73,10 @@
                 />
             </field>
             <group name="supplier_rma" position="after">
-                <group name="refund">
+                <group
+                    name="refund"
+                    attrs="{'invisible': [('refund_policy', '=', 'no')]}"
+                >
                     <field name="qty_to_refund" />
                     <field name="qty_refunded" />
                 </group>

--- a/rma_account/wizards/rma_refund.xml
+++ b/rma_account/wizards/rma_refund.xml
@@ -59,13 +59,13 @@
                     name="%(action_rma_refund)d"
                     string="Create Refund"
                     class="oe_highlight"
-                    attrs="{'invisible':['|', ('qty_to_refund', '=', 0), ('state', '!=', 'approved')]}"
+                    attrs="{'invisible':['|', '|', ('qty_to_refund', '=', 0), ('state', '!=', 'approved'), ('refund_policy', '=', 'no')]}"
                     type="action"
                 />
                 <button
                     name="%(action_rma_refund)d"
                     string="Create Refund"
-                    attrs="{'invisible':['|', ('qty_to_refund', '!=', 0), ('state', '!=', 'approved')]}"
+                    attrs="{'invisible':['|', '|', ('qty_to_refund', '!=', 0), ('state', '!=', 'approved'), ('refund_policy', '=', 'no')]}"
                     type="action"
                 />
             </xpath>

--- a/rma_sale/views/rma_order_line_view.xml
+++ b/rma_sale/views/rma_order_line_view.xml
@@ -30,7 +30,7 @@
                 />
                 </group>
                 <group name="quantities" position="inside">
-                    <group>
+                    <group attrs="{'invisible': [('sale_policy', '=', 'no')]}">
                         <field name="qty_to_sell" />
                         <field name="qty_sold" />
                     </group>
@@ -45,7 +45,11 @@
                 />
                 </field>
                 <notebook position="inside">
-                    <page name="sale" string="Sale Lines">
+                    <page
+                    name="sale"
+                    string="Sale Lines"
+                    attrs="{'invisible': [('sale_line_ids', '=', [])]}"
+                >
                         <field name="sale_line_ids" nolabel="1" />
                     </page>
                 </notebook>
@@ -62,13 +66,13 @@
                     name="%(action_rma_order_line_make_sale_order)d"
                     string="Create Sales Quotation"
                     class="oe_highlight"
-                    attrs="{'invisible':['|', ('qty_to_sell', '=', 0), ('state', '!=', 'approved')]}"
+                    attrs="{'invisible':['|', '|', ('qty_to_sell', '=', 0), ('state', '!=', 'approved'), ('sale_policy', '=', 'no')]}"
                     type="action"
                 />
                 <button
                     name="%(action_rma_order_line_make_sale_order)d"
                     string="Create Sales Quotation"
-                    attrs="{'invisible':['|', ('qty_to_sell', '!=', 0), ('state', '!=', 'approved')]}"
+                    attrs="{'invisible':['|', '|', ('qty_to_sell', '!=', 0), ('state', '!=', 'approved'), ('sale_policy', '=', 'no')]}"
                     type="action"
                 />
             </header>


### PR DESCRIPTION
In this PR, I hide the buttons used to generate document (delivery, reception, refund, etc) if the related policy is set to "no".
When the related policy is "no" and we click on the button, a error is raised to the user anyway.
I also hide the policy related quantity fields when the policy is set to "no".

With this, I think the view is really simpler and the user still has full flexibility since he can change the policy anyway.

It is kind of a complement to https://github.com/ForgeFlow/stock-rma/pull/273

@JordiBForgeFlow 