### PR TITLE
[14.0][IMP] rma_filter_lot: add possibility to select only the lots issued specifically to the customer of the RMA.

### DIFF
--- a/rma_filter_lot/README.rst
+++ b/rma_filter_lot/README.rst
@@ -27,6 +27,7 @@ Contributors
 
 * Mateu Griful <mateu.griful@forgeflow.com>
 * Lois Rilo <lois.rilo@forgeflow.com>
+* Jordi Ballester <jordi.ballester@forgeflow.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/rma_filter_lot/__manifest__.py
+++ b/rma_filter_lot/__manifest__.py
@@ -3,15 +3,13 @@
 
 {
     "name": "RMA Filter Lot",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.1.0",
     "license": "LGPL-3",
     "category": "RMA",
     "summary": "Filter RMA lots",
     "author": "ForgeFlow",
     "website": "https://github.com/ForgeFlow/stock-rma",
     "depends": ["rma"],
-    "data": [
-        "views/rma_order_view.xml",
-    ],
+    "data": ["views/rma_order_view.xml"],
     "installable": True,
 }

--- a/rma_filter_lot/views/rma_order_view.xml
+++ b/rma_filter_lot/views/rma_order_view.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" ?>
 <odoo>
     <record id="view_rma_line_form" model="ir.ui.view">
         <field name="name">rma.order.line.form</field>


### PR DESCRIPTION
Show only the lots shipped to the particular customer in the RMA. If nothing was shipped to that customer, fall back to showing all the lots available in the customer location.


