### PR TITLE
[14.0][IMP]rma_sale_auto_routes_and_confirm: done!

### DIFF
--- a/rma_sale_auto_routes_and_confirm/README.rst
+++ b/rma_sale_auto_routes_and_confirm/README.rst
@@ -1,0 +1,32 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License LGPL-3
+
+===================
+RMA Sale Auto Route
+===================
+
+When a Sales Order is created from RMA, it only allows to confirm it if all the products are available and it sets the recommended route.
+
+Configuration
+=============
+
+Already set up when Installed.
+
+Usage
+=====
+
+When a Sales Order is created from RMA, When a Sales Order is created from RMA, it only allows to confirm it if all the products are available and  it sets the recommended route.
+
+Credits
+=======
+
+Contributors
+------------
+
+* David Jimenez <david.jimenez@forgeflow.com>
+
+
+Maintainer
+----------
+
+This module is maintained by ForgeFlow

--- a/rma_sale_auto_routes_and_confirm/__init__.py
+++ b/rma_sale_auto_routes_and_confirm/__init__.py
@@ -1,0 +1,1 @@
+from . import wizards

--- a/rma_sale_auto_routes_and_confirm/__manifest__.py
+++ b/rma_sale_auto_routes_and_confirm/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "Rma Sale Auto Route",
+    "version": "14.0.1.0.0",
+    "license": "LGPL-3",
+    "category": "RMA",
+    "summary": "Allows the user to create Sales Orders that can only be "
+    "validated if all products are available.",
+    "author": "ForgeFlow",
+    "website": "https://github.com/ForgeFlow/stock-rma",
+    "depends": [
+        "sale_route_on_available_quantity",
+        "sale_confirm_on_availability",
+        "rma_sale",
+    ],
+    "data": [],
+    "installable": True,
+    "auto_install": True,
+}

--- a/rma_sale_auto_routes_and_confirm/wizards/__init__.py
+++ b/rma_sale_auto_routes_and_confirm/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import rma_order_line_make_sale_order

--- a/rma_sale_auto_routes_and_confirm/wizards/rma_order_line_make_sale_order.py
+++ b/rma_sale_auto_routes_and_confirm/wizards/rma_order_line_make_sale_order.py
@@ -1,0 +1,16 @@
+from odoo import models
+
+
+class RmaLineMakeSaleOrder(models.TransientModel):
+    _inherit = "rma.order.line.make.sale.order"
+
+    def make_sale_order(self):
+        res = super(RmaLineMakeSaleOrder, self).make_sale_order()
+        split = res["domain"].split("[")
+        split = split[2].split("]")
+        sales_id = split[0].split(",")
+        sales_id = self.env["sale.order"].browse([int(sales_id[0])])
+        sales_id.only_confirm_if_all_products_are_available = True
+        sales_id.propose_rule_on_available_quantity = True
+        sales_id._onchange_propose_rule_on_available_quantity()
+        return res


### PR DESCRIPTION
When a Sales Order is created from RMA, it only allows to confirm it if all the products are available and it sets the recommended route.

@ForgeFlow