### PR TITLE
[14.0][FIX] rma*: Ensure that configuration on the operation is applied

### DIFF
--- a/rma/wizards/rma_add_serial.py
+++ b/rma/wizards/rma_add_serial.py
@@ -133,5 +133,11 @@ class RmaAddSerialWiz(models.TransientModel):
                 )
 
             vals = self._prepare_rma_line_from_lot_vals(lot)
-            rma_line_obj.create(vals)
+            rec = rma_line_obj.create(vals)
+            # Ensure that configuration on the operation is applied (like
+            #  policies).
+            # TODO MIG: in v16 the usage of such onchange can be removed in
+            #  favor of (pre)computed stored editable fields for all policies
+            #  and configuration in the RMA operation.
+            rec._onchange_operation_id()
         return {"type": "ir.actions.act_window_close"}

--- a/rma/wizards/rma_add_stock_move.py
+++ b/rma/wizards/rma_add_stock_move.py
@@ -160,9 +160,15 @@ class RmaAddStockMove(models.TransientModel):
             if sm not in existing_stock_moves or tracking_move:
                 if sm.product_id.tracking == "none":
                     data = self._prepare_rma_line_from_stock_move(sm, lot=False)
-                    rma_line_obj.with_context(default_rma_id=self.rma_id.id).create(
-                        data
-                    )
+                    rec = rma_line_obj.with_context(
+                        default_rma_id=self.rma_id.id
+                    ).create(data)
+                    # Ensure that configuration on the operation is applied (like
+                    #  policies).
+                    # TODO MIG: in v16 the usage of such onchange can be removed in
+                    #  favor of (pre)computed stored editable fields for all policies
+                    #  and configuration in the RMA operation.
+                    rec._onchange_operation_id()
                 else:
                     for lot in sm.move_line_ids.mapped("lot_id").filtered(
                         lambda x: x.id in self.lot_ids.ids
@@ -170,7 +176,13 @@ class RmaAddStockMove(models.TransientModel):
                         if lot.id in self.rma_id.rma_line_ids.mapped("lot_id").ids:
                             continue
                         data = self._prepare_rma_line_from_stock_move(sm, lot)
-                        rma_line_obj.with_context(default_rma_id=self.rma_id.id).create(
-                            data
-                        )
+                        rec = rma_line_obj.with_context(
+                            default_rma_id=self.rma_id.id
+                        ).create(data)
+                        # Ensure that configuration on the operation is applied (like
+                        #  policies).
+                        # TODO MIG: in v16 the usage of such onchange can be removed in
+                        #  favor of (pre)computed stored editable fields for all policies
+                        #  and configuration in the RMA operation.
+                        rec._onchange_operation_id()
         return {"type": "ir.actions.act_window_close"}

--- a/rma/wizards/rma_order_line_make_supplier_rma.py
+++ b/rma/wizards/rma_order_line_make_supplier_rma.py
@@ -157,7 +157,13 @@ class RmaLineMakeSupplierRma(models.TransientModel):
                 rma = rma_obj.create(rma_data)
 
             rma_line_data = self._prepare_supplier_rma_line(rma, item)
-            rma_line_obj.create(rma_line_data)
+            rec = rma_line_obj.create(rma_line_data)
+            # Ensure that configuration on the operation is applied (like
+            #  policies).
+            # TODO MIG: in v16 the usage of such onchange can be removed in
+            #  favor of (pre)computed stored editable fields for all policies
+            #  and configuration in the RMA operation.
+            rec._onchange_operation_id()
         action = self.env.ref("rma.action_rma_supplier_lines")
         rma_lines = self.item_ids.mapped("line_id.supplier_rma_line_ids").ids
         result = action.sudo().read()[0]

--- a/rma_account/wizards/rma_add_account_move.py
+++ b/rma_account/wizards/rma_add_account_move.py
@@ -128,7 +128,13 @@ class RmaAddAccountMove(models.TransientModel):
             # Load a PO line only once
             if line not in existing_invoice_lines:
                 data = self._prepare_rma_line_from_inv_line(line)
-                rma_line_obj.create(data)
+                rec = rma_line_obj.create(data)
+                # Ensure that configuration on the operation is applied (like
+                #  policies).
+                # TODO MIG: in v16 the usage of such onchange can be removed in
+                #  favor of (pre)computed stored editable fields for all policies
+                #  and configuration in the RMA operation.
+                rec._onchange_operation_id()
         rma = self.rma_id
         data_rma = self._get_rma_data()
         rma.write(data_rma)

--- a/rma_purchase/wizards/rma_add_purchase.py
+++ b/rma_purchase/wizards/rma_add_purchase.py
@@ -128,7 +128,12 @@ class RmaAddPurchase(models.TransientModel):
             # Load a PO line only once
             if line not in existing_purchase_lines:
                 data = self._prepare_rma_line_from_po_line(line)
-                rma_line_obj.create(data)
+                rec = rma_line_obj.create(data)
+                # Ensure that configuration on the operation is applied
+                # TODO MIG: in v16 the usage of such onchange can be removed in
+                #  favor of (pre)computed stored editable fields for all policies
+                #  and configuration in the RMA operation.
+                rec._onchange_operation_id()
         rma = self.rma_id
         data_rma = self._get_rma_data()
         rma.write(data_rma)

--- a/rma_sale/wizards/rma_add_sale.py
+++ b/rma_sale/wizards/rma_add_sale.py
@@ -175,7 +175,12 @@ class RmaAddSale(models.TransientModel):
             if line not in existing_sale_lines or tracking_move:
                 if not tracking_move:
                     data = self._prepare_rma_line_from_sale_order_line(line)
-                    rma_line_obj.create(data)
+                    rec = rma_line_obj.create(data)
+                    # Ensure that configuration on the operation is applied
+                    # TODO MIG: in v16 the usage of such onchange can be removed in
+                    #  favor of (pre)computed stored editable fields for all policies
+                    #  and configuration in the RMA operation.
+                    rec._onchange_operation_id()
                 else:
                     for lot in line.mapped("move_ids.move_line_ids.lot_id").filtered(
                         lambda x: x.id in self.lot_ids.ids
@@ -183,7 +188,12 @@ class RmaAddSale(models.TransientModel):
                         if lot.id in self.rma_id.rma_line_ids.mapped("lot_id").ids:
                             continue
                         data = self._prepare_rma_line_from_sale_order_line(line, lot)
-                        rma_line_obj.create(data)
+                        rec = rma_line_obj.create(data)
+                        # Ensure that configuration on the operation is applied
+                        # TODO MIG: in v16 the usage of such onchange can be removed in
+                        #  favor of (pre)computed stored editable fields for all policies
+                        #  and configuration in the RMA operation.
+                        rec._onchange_operation_id()
         rma = self.rma_id
         data_rma = self._get_rma_data()
         rma.write(data_rma)


### PR DESCRIPTION
Without this, some policies are not being copied from the
operation selected when creating new rma line from a rma group.
    
In v16 this patch and the usage of such onchange can be removed
in favor of (pre)computed stored editable fields for all policies
and configuration in the RMA operation.

@ForgeFlow
