### PR TITLE
[16.0][FIX] rma: Ensure that configuration on the operation is applied

### DIFF
--- a/rma/wizards/rma_add_serial.py
+++ b/rma/wizards/rma_add_serial.py
@@ -133,5 +133,11 @@ class RmaAddSerialWiz(models.TransientModel):
                 )
 
             vals = self._prepare_rma_line_from_lot_vals(lot)
-            rma_line_obj.create(vals)
+            rec = rma_line_obj.create(vals)
+            # Ensure that configuration on the operation is applied (like
+            #  policies).
+            # TODO MIG: in v16 the usage of such onchange can be removed in
+            #  favor of (pre)computed stored editable fields for all policies
+            #  and configuration in the RMA operation.
+            rec._onchange_operation_id()
         return {"type": "ir.actions.act_window_close"}

--- a/rma/wizards/rma_order_line_make_supplier_rma.py
+++ b/rma/wizards/rma_order_line_make_supplier_rma.py
@@ -157,7 +157,13 @@ class RmaLineMakeSupplierRma(models.TransientModel):
                 rma = rma_obj.create(rma_data)
 
             rma_line_data = self._prepare_supplier_rma_line(rma, item)
-            rma_line_obj.create(rma_line_data)
+            rec = rma_line_obj.create(rma_line_data)
+            # Ensure that configuration on the operation is applied (like
+            #  policies).
+            # TODO MIG: in v16 the usage of such onchange can be removed in
+            #  favor of (pre)computed stored editable fields for all policies
+            #  and configuration in the RMA operation.
+            rec._onchange_operation_id()
         action = self.env.ref("rma.action_rma_supplier_lines")
         rma_lines = self.item_ids.mapped("line_id.supplier_rma_line_ids").ids
         result = action.sudo().read()[0]


### PR DESCRIPTION
Without this, some policies are not being copied from the operation selected when creating new rma line from a rma group.

In v16 this patch and the usage of such onchange can be removed in favor of (pre)computed stored editable fields for all policies and configuration in the RMA operation. For now we migrate as is and will take care of the refactor in a new PR.

Forward port of #355 