### PR TITLE
[14.0][FIX] rma_sale: description not passed to SO

### DIFF
--- a/rma_sale/wizards/rma_order_line_make_sale_order.py
+++ b/rma_sale/wizards/rma_order_line_make_sale_order.py
@@ -97,7 +97,7 @@ class RmaLineMakeSaleOrder(models.TransientModel):
     def _prepare_sale_order_line(self, so, item):
         product = item.product_id
         vals = {
-            "name": product.name,
+            "name": item.name,
             "order_id": so.id,
             "product_id": product.id,
             "product_uom": product.uom_po_id.id,


### PR DESCRIPTION
The description wasn't being passed to the SO when changing it at the RMA wizard.


@ForgeFlow