### PR TITLE
[14.0][FIX] rma: add stock move in supplier group

### DIFF
--- a/rma/wizards/rma_add_stock_move_view.xml
+++ b/rma/wizards/rma_add_stock_move_view.xml
@@ -117,6 +117,29 @@
                 </group>
                 <separator string="Select Stock Moves to add" />
                 <field name="move_ids" />
+                <field name="show_lot_filter" invisible="1" />
+                <field name="lot_domain_ids" widget="many2many_tags" invisible="1" />
+                <div class="o_row">
+                    <label
+                        for="lot_ids"
+                        attrs="{'invisible': [('show_lot_filter', '=', False)]}"
+                        string="Selected Lot/Serial Numbers"
+                    />
+                    <field
+                        name="lot_ids"
+                        widget="many2many_tags"
+                        domain="[('id', 'in', lot_domain_ids)]"
+                        attrs="{'invisible': [('show_lot_filter', '=', False)]}"
+                        options="{'no_create': True}"
+                    />
+                    <button
+                        name="select_all"
+                        type="object"
+                        string="Select all"
+                        class="oe_inline"
+                        attrs="{'invisible': [('show_lot_filter', '=', False)]}"
+                    />
+                </div>
                 <footer>
                     <button
                         string="Confirm"


### PR DESCRIPTION
You cannot add rma_lines before because the lot_ids field in the wizard was not being settled.

@ForgeFlow