### PR TITLE
[14.0][FIX] rma_sale: duplicate SO also link rma

### DIFF
--- a/rma_sale/models/sale_order_line.py
+++ b/rma_sale/models/sale_order_line.py
@@ -62,7 +62,7 @@ class SaleOrderLine(models.Model):
             return super(SaleOrderLine, self).name_get()
 
     rma_line_id = fields.Many2one(
-        comodel_name="rma.order.line", string="RMA", ondelete="restrict"
+        comodel_name="rma.order.line", string="RMA", ondelete="restrict", copy=False
     )
 
     def _prepare_order_line_procurement(self, group_id=False):


### PR DESCRIPTION
When duplicating an SO that is linked to an RMA, also links the duplicated one to the original RMA.

@ForgeFlow