### PR TITLE
[14.0][IMP] rma: cancel rma_lines

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -254,6 +254,7 @@ class RmaOrderLine(models.Model):
             ("to_approve", "To Approve"),
             ("approved", "Approved"),
             ("done", "Done"),
+            ("canceled", "Canceled"),
         ],
         string="State",
         default="draft",
@@ -650,6 +651,25 @@ class RmaOrderLine(models.Model):
 
     def action_rma_done(self):
         self.write({"state": "done"})
+        return True
+
+    def check_cancel(self):
+        for move in self.move_ids:
+            if move.state == "done":
+                raise UserError(
+                    _("Unable to cancel %s as some receptions have already been done.")
+                    % (self.name)
+                )
+
+    def action_rma_cancel(self):
+        for order in self:
+            order.check_cancel()
+            order.write({"state": "canceled"})
+            order.move_ids._action_cancel()
+            shipments = order._get_in_pickings()
+            shipments |= order._get_out_pickings()
+            for ship in shipments:
+                ship.action_cancel()
         return True
 
     @api.model

--- a/rma/views/rma_order_line_view.xml
+++ b/rma/views/rma_order_line_view.xml
@@ -96,7 +96,14 @@
                             name="action_rma_done"
                             type="object"
                             string="Done"
-                            attrs="{'invisible':[('state', 'in', ('done', 'draft'))]}"
+                            attrs="{'invisible':[('state', 'in', ('done', 'draft', 'canceled'))]}"
+                            groups="rma.group_rma_customer_user"
+                        />
+                        <button
+                            name="action_rma_cancel"
+                            type="object"
+                            string="Cancel"
+                            attrs="{'invisible':[('state', 'in', ('done', 'canceled'))]}"
                             groups="rma.group_rma_customer_user"
                         />
                         <field name="state" widget="statusbar" nolabel="1" />
@@ -489,6 +496,16 @@
             <field name="code">
 if records.filtered(lambda x: x.state == "draft"):
     records.filtered(lambda x: x.state == "draft").action_rma_to_approve()
+            </field>
+     </record>
+
+        <record model="ir.actions.server" id="action_request_cancel_rma_order_line">
+            <field name="name">Cancel</field>
+            <field name="model_id" ref="rma.model_rma_order_line" />
+            <field name="binding_model_id" ref="rma.model_rma_order_line" />
+            <field name="state">code</field>
+            <field name="code">
+    records.action_rma_cancel()
             </field>
      </record>
 


### PR DESCRIPTION
This allows to cancel RMA lines if no stock move is in state done. Also cancels related pickings if existing. 


@ForgeFlow