### PR TITLE
[14.0][IMP] rma_purchase: button cancel

### DIFF
--- a/rma_purchase/models/rma_order_line.py
+++ b/rma_purchase/models/rma_order_line.py
@@ -218,6 +218,12 @@ class RmaOrderLine(models.Model):
         result["domain"] = [("id", "in", orders.ids)]
         return result
 
+    def action_rma_cancel(self):
+        res = super().action_rma_cancel()
+        for line in self:
+            line.purchase_order_line_ids.mapped("order_id").button_cancel()
+        return res
+
     def _get_rma_purchased_qty(self):
         self.ensure_one()
         qty = 0.0


### PR DESCRIPTION
This module extends the functionality of the cancellation of RMA and cancels related purchase order.

Depends on #376 

@ForgeFlow