### PR TITLE
[14.0][IMP] rma_sale: button cancel

### DIFF
--- a/rma_sale/models/rma_order_line.py
+++ b/rma_sale/models/rma_order_line.py
@@ -210,6 +210,12 @@ class RmaOrderLine(models.Model):
         result["domain"] = [("id", "in", order_ids)]
         return result
 
+    def action_rma_cancel(self):
+        res = super().action_rma_cancel()
+        for line in self:
+            line.sale_line_ids.mapped("order_id").action_cancel()
+        return res
+
     def _get_rma_sold_qty(self):
         self.ensure_one()
         qty = 0.0


### PR DESCRIPTION
This module extends the functionality of the cancellation of RMA and cancels related sales order.

Depends on #376 

@ForgeFlow