### PR TITLE
[14.0][IMP] rma_repair: button cancel

### DIFF
--- a/rma_repair/models/rma_order_line.py
+++ b/rma_repair/models/rma_order_line.py
@@ -130,6 +130,12 @@ class RmaOrderLine(models.Model):
             result["res_id"] = repair_ids[0]
         return result
 
+    def action_rma_cancel(self):
+        res = super().action_rma_cancel()
+        for line in self:
+            line.repair_ids.action_repair_cancel()
+        return res
+
     def _get_rma_repaired_qty(self):
         self.ensure_one()
         qty = 0.0


### PR DESCRIPTION
This module extends the functionality of the cancellation of RMA and cancels related repair order.

Depends on #376 

@ForgeFlow