### PR TITLE
[14.0][FIX] rma: in multi step routes, only reserve first step

### DIFF
--- a/rma/wizards/rma_make_picking.py
+++ b/rma/wizards/rma_make_picking.py
@@ -210,7 +210,7 @@ class RmaMakePicking(models.TransientModel):
             # Force the reservation of the RMA specific lot for incoming shipments.
             # FIXME: still needs fixing, not reserving appropriate serials.
             for move in pickings.move_lines.filtered(
-                lambda x: x.state not in ("draft", "cancel", "done")
+                lambda x: x.state not in ("draft", "cancel", "done", "waiting")
                 and x.rma_line_id
                 and x.product_id.tracking in ("lot", "serial")
                 and x.rma_line_id.lot_id


### PR DESCRIPTION
We shoul not force reservation on next steps on a multi step route, oherwise a inconsistency is generated and the transfers cannot be processed or cancel so the user gets stuck ("it is not possible to unreserve more products that you have in stock" error).