### PR TITLE
[14.0][IMP] rma: limit state statusbar

### DIFF
--- a/rma/views/rma_order_line_view.xml
+++ b/rma/views/rma_order_line_view.xml
@@ -106,7 +106,12 @@
                             attrs="{'invisible':[('state', 'in', ('done', 'canceled'))]}"
                             groups="rma.group_rma_customer_user"
                         />
-                        <field name="state" widget="statusbar" nolabel="1" />
+                        <field
+                            name="state"
+                            widget="statusbar"
+                            statusbar_visible="draft,to_approve,approved,done"
+                            nolabel="1"
+                        />
                     </header>
                     <sheet>
                         <div name="button_box" class="oe_button_box">


### PR DESCRIPTION
Limit widget statusbar in rma line to only contain draft, to approve, approved and done.


@ForgeFlow 