### PR TITLE
[16.0][FIX] rma: return of button done

### DIFF
--- a/rma/views/rma_order_line_view.xml
+++ b/rma/views/rma_order_line_view.xml
@@ -86,6 +86,13 @@
                         groups="rma.group_rma_customer_user"
                     />
                         <button
+                        name="action_rma_done"
+                        type="object"
+                        string="Done"
+                        attrs="{'invisible':[('state', 'in', ('done', 'draft', 'canceled'))]}"
+                        groups="rma.group_rma_customer_user"
+                    />
+                        <button
                         name="action_rma_cancel"
                         type="object"
                         string="Cancel"


### PR DESCRIPTION
I erased by accident that button in a previous commit.

@LoisRForgeFlow 