### PR TITLE
[16.0][FIX] rma: product_uom_qty not in move_line_ids

### DIFF
--- a/rma/wizards/rma_make_picking.py
+++ b/rma/wizards/rma_make_picking.py
@@ -246,7 +246,7 @@ class RmaMakePicking(models.TransientModel):
                             "lot_id": move.rma_line_id.lot_id.id,
                             "product_uom_id": move.product_id.uom_id.id,
                             "qty_done": 0,
-                            "product_uom_qty": qty,
+                            "reserved_uom_qty": qty,
                         }
                     )
                     move_line_model.create(move_line_data)


### PR DESCRIPTION
In Odoo 16.0 "stock.move.line" has no longer field product_uom_qty, now it's reserved_uom_qty.

@ForgeFlow