### PR TITLE
[16.0][FIX] rma: multiple fixes

### DIFF
--- a/rma/models/res_partner.py
+++ b/rma/models/res_partner.py
@@ -22,4 +22,6 @@ class ResPartner(models.Model):
         action = self.env.ref("rma.action_rma_customer_lines")
         result = action.sudo().read()[0]
         result["context"] = {"search_default_partner_id": self.id}
+        result["domain"] = []
+        result["display_name"] = "Partner RMAs"
         return result

--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -77,7 +77,10 @@ class RmaOrderLine(models.Model):
         for move in self.move_ids:
             first_usage = move._get_first_usage()
             last_usage = move._get_last_usage()
-            if first_usage in ("internal", "production") and last_usage != "internal":
+            if first_usage in ("internal", "production") and last_usage in (
+                "customer",
+                "supplier",
+            ):
                 pickings |= move.picking_id
             elif last_usage == "customer" and first_usage == "supplier":
                 pickings |= move.picking_id
@@ -98,12 +101,24 @@ class RmaOrderLine(models.Model):
             product_obj = self.env["uom.uom"]
             qty = 0.0
             if direction == "in":
-                op = ops["="]
-            else:
-                op = ops["!="]
-            for move in rec.move_ids.filtered(
-                lambda m: m.state in states and op(m.location_id.usage, rec.type)
-            ):
+                moves = rec.move_ids.filtered(
+                    lambda m: m.state in states
+                    and (
+                        m.location_id.usage == "supplier"
+                        or m.location_id.usage == "customer"
+                    )
+                    and m.location_dest_id.usage == "internal"
+                )
+            elif direction == "out":
+                moves = rec.move_ids.filtered(
+                    lambda m: m.state in states
+                    and (
+                        m.location_dest_id.usage == "supplier"
+                        or m.location_dest_id.usage == "customer"
+                    )
+                    and m.location_id.usage == "internal"
+                )
+            for move in moves:
                 # If the move is part of a chain don't count it
                 if direction == "out" and move.move_orig_ids:
                     continue

--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -68,7 +68,7 @@ class RmaOrderLine(models.Model):
             if last_usage == "internal" and first_usage != "internal":
                 moves |= move
             elif last_usage == "supplier" and first_usage == "customer":
-                moves |= moves
+                moves |= move
         return moves
 
     @api.model
@@ -107,7 +107,10 @@ class RmaOrderLine(models.Model):
                         m.location_id.usage == "supplier"
                         or m.location_id.usage == "customer"
                     )
-                    and m.location_dest_id.usage == "internal"
+                    and (
+                        m.location_dest_id.usage == "internal"
+                        or m.location_dest_id.usage == "supplier"
+                    )
                 )
             elif direction == "out":
                 moves = rec.move_ids.filtered(
@@ -116,7 +119,10 @@ class RmaOrderLine(models.Model):
                         m.location_dest_id.usage == "supplier"
                         or m.location_dest_id.usage == "customer"
                     )
-                    and m.location_id.usage == "internal"
+                    and (
+                        m.location_id.usage == "internal"
+                        or m.location_id.usage == "supplier"
+                    )
                 )
             for move in moves:
                 # If the move is part of a chain don't count it

--- a/rma/views/rma_order_line_view.xml
+++ b/rma/views/rma_order_line_view.xml
@@ -387,7 +387,7 @@
                     <field name="lot_id" />
                     <separator />
                     <filter
-                    name="assigned_to"
+                    name="assigned_to_filter"
                     domain="[('assigned_to','=',uid)]"
                     help="My RMAs"
                 />
@@ -457,7 +457,7 @@
             <field name="name">Customer RMA</field>
             <field name="res_model">rma.order.line</field>
             <field name="domain">[('type','=', 'customer')]</field>
-            <field name="context">{"search_default_assigned_to":uid}</field>
+            <field name="context">{"search_default_assigned_to_filter":1}</field>
             <field name="view_mode">tree,form</field>
             <field name="view_id" ref="view_rma_line_tree" />
         </record>
@@ -468,7 +468,7 @@
             <field name="domain">[('type','=', 'supplier')]</field>
             <field
             name="context"
-        >{"search_default_assigned_to":uid, "supplier":1}</field>
+        >{"search_default_assigned_to_filter":1, "supplier":1}</field>
             <field name="view_mode">tree,form</field>
             <field name="view_id" ref="view_rma_line_supplier_tree" />
         </record>

--- a/rma/views/stock_view.xml
+++ b/rma/views/stock_view.xml
@@ -18,9 +18,9 @@
         <field name="inherit_id" ref="stock.stock_location_route_form_view" />
         <field name="model">stock.route</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='warehouse_selectable']" position="before">
+            <label for="warehouse_selectable" position="before">
                 <field name="rma_selectable" string="RMA Order Lines" />
-            </xpath>
+            </label>
         </field>
     </record>
 </odoo>

--- a/rma/wizards/rma_make_picking.py
+++ b/rma/wizards/rma_make_picking.py
@@ -102,17 +102,19 @@ class RmaMakePicking(models.TransientModel):
     def _get_procurement_data(self, item, group, qty, picking_type):
         line = item.line_id
         delivery_address_id = self._get_address(item)
+        location, warehouse, route = False, False, False
         if picking_type == "incoming":
             if line.customer_to_supplier:
                 location = self._get_address_location(delivery_address_id, "supplier")
-            elif line.supplier_to_customer:
-                location = self._get_address_location(delivery_address_id, "customer")
             else:
                 location = line.location_id
             warehouse = line.in_warehouse_id
             route = line.in_route_id
-        else:
-            location = self._get_address_location(delivery_address_id, line.type)
+        elif picking_type == "outgoing":
+            if line.supplier_to_customer:
+                location = self._get_address_location(delivery_address_id, "customer")
+            else:
+                location = self._get_address_location(delivery_address_id, line.type)
             warehouse = line.out_warehouse_id
             route = line.out_route_id
         if not route:

--- a/rma/wizards/rma_make_picking.py
+++ b/rma/wizards/rma_make_picking.py
@@ -227,7 +227,7 @@ class RmaMakePicking(models.TransientModel):
                     )
                     move.move_line_ids.write(
                         {
-                            "product_uom_qty": 1,
+                            "reserved_uom_qty": 1,
                             "qty_done": 0,
                         }
                     )
@@ -246,7 +246,7 @@ class RmaMakePicking(models.TransientModel):
                             "lot_id": move.rma_line_id.lot_id.id,
                             "product_uom_id": move.product_id.uom_id.id,
                             "qty_done": 0,
-                            "product_uom_qty": qty,
+                            "reserved_uom_qty": qty,
                         }
                     )
                     move_line_model.create(move_line_data)

--- a/rma/wizards/rma_make_picking_view.xml
+++ b/rma/wizards/rma_make_picking_view.xml
@@ -108,26 +108,26 @@
                     name="%(action_rma_picking_in)d"
                     string="Create Incoming Shipment"
                     class="oe_highlight"
-                    attrs="{'invisible':['|', '|', ('qty_to_receive', '=', 0), ('state', '!=', 'approved'), ('receipt_policy', '=', 'no')]}"
+                    attrs="{'invisible':['|', '|', '|', ('qty_to_receive', '=', 0), ('qty_to_receive', '&lt;', 0), ('state', '!=', 'approved'), ('receipt_policy', '=', 'no')]}"
                     type="action"
                 />
                 <button
                     name="%(action_rma_picking_in)d"
                     string="Create Incoming Shipment"
-                    attrs="{'invisible':['|', '|', ('qty_to_receive', '!=', 0), ('state', '!=', 'approved'), ('receipt_policy', '=', 'no')]}"
+                    attrs="{'invisible':['|', '|', ('qty_to_receive', '>', 0), ('state', '!=', 'approved'), ('receipt_policy', '=', 'no')]}"
                     type="action"
                 />
                 <button
                     name="%(action_rma_picking_out)d"
                     string="Create Delivery"
                     class="oe_highlight"
-                    attrs="{'invisible':['|', '|', ('qty_to_deliver', '=', 0), ('state', '!=', 'approved'), ('delivery_policy', '=', 'no')]}"
+                    attrs="{'invisible':['|', '|', '|', ('qty_to_deliver', '=', 0), ('qty_to_deliver', '&lt;', 0), ('state', '!=', 'approved'), ('delivery_policy', '=', 'no')]}"
                     type="action"
                 />
                 <button
                     name="%(action_rma_picking_out)d"
                     string="Create Delivery"
-                    attrs="{'invisible':['|', '|', ('qty_to_deliver', '!=', 0), ('state', '!=', 'approved'), ('delivery_policy', '=', 'no')]}"
+                    attrs="{'invisible':['|', '|', ('qty_to_deliver', '>', 0), ('state', '!=', 'approved'), ('delivery_policy', '=', 'no')]}"
                     type="action"
                 />
             </header>


### PR DESCRIPTION
Error in migration, this fixes it. stock.move.line.product_uom_qty to stock.move.line.reserved_uom_qty.

Also corrects the position of field rma_selectable in routes form view.

Deliveries are computed now as a move going out to "customers" or "suppliers".

Assigned to filter now only applied once.

@ForgeFlow