### PR TITLE
[16.0][IMP] rma_repair: create transfer from RMA to Repair location

### DIFF
--- a/rma_repair/models/__init__.py
+++ b/rma_repair/models/__init__.py
@@ -4,3 +4,5 @@ from . import repair
 from . import rma_order_line
 from . import rma_order
 from . import rma_operation
+from . import stock_move
+from . import stock_rule

--- a/rma_repair/models/rma_operation.py
+++ b/rma_repair/models/rma_operation.py
@@ -35,3 +35,8 @@ class RmaOperation(models.Model):
         "respectively. 'No invoice' means you don't want to generate "
         "invoice for this repair order.",
     )
+    repair_route_id = fields.Many2one(
+        comodel_name="stock.route",
+        string="Repair Route",
+        domain=[("rma_selectable", "=", True)],
+    )

--- a/rma_repair/models/rma_order.py
+++ b/rma_repair/models/rma_order.py
@@ -12,8 +12,21 @@ class RmaOrder(models.Model):
             repairs = rma.mapped("rma_line_ids.repair_ids")
             rma.repair_count = len(repairs)
 
+    def _compute_repair_transfer_count(self):
+        for order in self:
+            pickings = (
+                order.mapped("rma_line_ids.move_ids")
+                .filtered(lambda m: m.is_rma_put_away)
+                .mapped("picking_id")
+            )
+            order.put_away_count = len(pickings)
+
     repair_count = fields.Integer(
         compute="_compute_repair_count", string="# of Repairs"
+    )
+
+    repair_transfer_count = fields.Integer(
+        compute="_compute_repair_transfer_count", string="# Repair Transfers"
     )
 
     def action_view_repair_order(self):
@@ -22,3 +35,14 @@ class RmaOrder(models.Model):
         repair_ids = self.mapped("rma_line_ids.repair_ids").ids
         result["domain"] = [("id", "in", repair_ids)]
         return result
+
+    def action_view_repair_transfers(self):
+        self.ensure_one()
+        action = self.env.ref("stock.action_picking_tree_all")
+        result = action.sudo().read()[0]
+        pickings = self.env["stock.picking"]
+        for line in self.rma_line_ids:
+            pickings |= line.move_ids.filtered(
+                lambda m: m.is_rma_repair_transfer
+            ).mapped("picking_id")
+        return self._view_shipments(result, pickings)

--- a/rma_repair/models/stock_move.py
+++ b/rma_repair/models/stock_move.py
@@ -1,0 +1,19 @@
+# Copyright 2022 ForgeFlow S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from odoo import fields, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    is_rma_repair_transfer = fields.Boolean(
+        string="Is RMA Repair",
+        help="This Stock Move has been created from a Repair operation in " "the RMA.",
+    )
+
+    def _is_in_out_rma_move(self, op, states, location_type):
+        res = super(StockMove, self)._is_in_out_rma_move(op, states, location_type)
+        if self.is_rma_repair_transfer:
+            return False
+        return res

--- a/rma_repair/models/stock_rule.py
+++ b/rma_repair/models/stock_rule.py
@@ -1,0 +1,33 @@
+# Copyright 2022 ForgeFlow S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    def _get_stock_move_values(
+        self,
+        product_id,
+        product_qty,
+        product_uom,
+        location_id,
+        name,
+        origin,
+        company_id,
+        values,
+    ):
+        res = super()._get_stock_move_values(
+            product_id,
+            product_qty,
+            product_uom,
+            location_id,
+            name,
+            origin,
+            company_id,
+            values,
+        )
+        if "is_rma_repair_transfer" in values:
+            res["is_rma_repair_transfer"] = values.get("is_rma_repair_transfer")
+        return res

--- a/rma_repair/tests/test_rma_repair.py
+++ b/rma_repair/tests/test_rma_repair.py
@@ -335,7 +335,6 @@ class TestRmaRepair(common.SingleTransactionCase):
         repair.invoice_method = "after_repair"
         repair.action_repair_confirm()
         repair.action_repair_start()
-        repair.action_force_availability()
         repair.action_repair_end()
         self.assertEqual(rma.qty_to_pay, 0.0)
         repair.action_repair_invoice_create()

--- a/rma_repair/tests/test_rma_repair.py
+++ b/rma_repair/tests/test_rma_repair.py
@@ -28,6 +28,36 @@ class TestRmaRepair(common.SingleTransactionCase):
         # Create partners
         cls.customer1 = cls.partner_obj.create({"name": "Customer 1"})
 
+        # Create routes
+        cls.wh = cls.env.ref("stock.warehouse0")
+        cls.stock_rma_location = cls.wh.lot_rma_id
+        cls.repair_loc = cls.env["stock.location"].create(
+            {
+                "name": "WH Repair Location",
+                "location_id": cls.wh.view_location_id.id,
+            }
+        )
+        cls.repair_route = cls.env["stock.route"].create(
+            {
+                "name": "Transfer RMA to Repair",
+                "rma_selectable": True,
+                "sequence": 10,
+            }
+        )
+
+        cls.env["stock.rule"].create(
+            {
+                "name": "Transfer",
+                "route_id": cls.repair_route.id,
+                "location_src_id": cls.stock_rma_location.id,
+                "location_dest_id": cls.repair_loc.id,
+                "action": "pull",
+                "picking_type_id": cls.wh.int_type_id.id,
+                "procure_method": "make_to_stock",
+                "warehouse_id": cls.wh.id,
+            }
+        )
+
         # Create RMA group and operation:
         cls.rma_group_customer = cls.rma_obj.create(
             {"partner_id": cls.customer1.id, "type": "customer"}
@@ -41,6 +71,8 @@ class TestRmaRepair(common.SingleTransactionCase):
                 "repair_type": "received",
                 "in_route_id": cls.rma_route_cust.id,
                 "out_route_id": cls.rma_route_cust.id,
+                "repair_location_id": cls.repair_loc.id,
+                "repair_route_id": cls.repair_route.id,
             }
         )
         cls.operation_2 = cls.rma_op.create(
@@ -52,6 +84,8 @@ class TestRmaRepair(common.SingleTransactionCase):
                 "repair_type": "ordered",
                 "in_route_id": cls.rma_route_cust.id,
                 "out_route_id": cls.rma_route_cust.id,
+                "repair_location_id": cls.repair_loc.id,
+                "repair_route_id": cls.repair_route.id,
             }
         )
         cls.operation_3 = cls.rma_op.create(
@@ -64,6 +98,8 @@ class TestRmaRepair(common.SingleTransactionCase):
                 "delivery_policy": "repair",
                 "in_route_id": cls.rma_route_cust.id,
                 "out_route_id": cls.rma_route_cust.id,
+                "repair_location_id": cls.repair_loc.id,
+                "repair_route_id": cls.repair_route.id,
             }
         )
         # Create products
@@ -154,14 +190,6 @@ class TestRmaRepair(common.SingleTransactionCase):
         cls.material.product_tmpl_id.standard_price = 10
         cls.stock_location = cls.env.ref("stock.stock_location_stock")
 
-        cls.env["stock.quant"].create(
-            {
-                "product_id": cls.material.id,
-                "location_id": cls.stock_location.id,
-                "quantity": 10,
-            }
-        )
-
     def test_01_add_from_invoice_customer(self):
         """Test wizard to create RMA from a customer invoice."""
         add_inv = self.rma_add_invoice_wiz.with_context(
@@ -217,6 +245,7 @@ class TestRmaRepair(common.SingleTransactionCase):
         self.assertEqual(rma.repair_count, 0)
         self.assertEqual(rma.qty_to_repair, 15.0)
         self.assertEqual(rma.qty_repaired, 0.0)
+        self.assertEqual(rma.repair_transfer_count, 0)
         make_repair = self.rma_make_repair_wiz.with_context(
             **{
                 "customer": True,
@@ -225,6 +254,14 @@ class TestRmaRepair(common.SingleTransactionCase):
             }
         ).new()
         make_repair.make_repair_order()
+        rma._compute_repair_transfer_count()
+        self.assertEqual(rma.repair_transfer_count, 1)
+        repair_transfer_move = rma.move_ids.filtered(
+            lambda x: x.location_dest_id == self.repair_loc
+        )
+        self.assertEqual(repair_transfer_move.location_id, self.stock_rma_location)
+        self.assertEqual(repair_transfer_move.product_qty, 15.0)
+        self.assertEqual(repair_transfer_move.product_id, rma.product_id)
         rma.repair_ids.action_repair_confirm()
         self.assertEqual(rma.repair_count, 1)
         self.assertEqual(rma.qty_to_repair, 0.0)
@@ -263,6 +300,7 @@ class TestRmaRepair(common.SingleTransactionCase):
         for mv in picking.move_ids:
             mv.quantity_done = mv.product_uom_qty
         picking._action_done()
+        self.assertEqual(rma.repair_transfer_count, 0)
         self.assertEqual(rma.qty_to_deliver, 0.0)
         make_repair = self.rma_make_repair_wiz.with_context(
             **{
@@ -272,6 +310,13 @@ class TestRmaRepair(common.SingleTransactionCase):
             }
         ).new()
         make_repair.make_repair_order()
+        rma._compute_repair_transfer_count()
+        self.assertEqual(rma.repair_transfer_count, 1)
+        repair_transfer_move = rma.move_ids.filtered(
+            lambda x: x.location_dest_id == self.repair_loc
+        )
+        self.assertEqual(repair_transfer_move.location_id, self.stock_rma_location)
+        self.assertEqual(repair_transfer_move.product_id, rma.product_id)
         repair = rma.repair_ids
         line = self.repair_line_obj.create(
             {
@@ -290,6 +335,7 @@ class TestRmaRepair(common.SingleTransactionCase):
         repair.invoice_method = "after_repair"
         repair.action_repair_confirm()
         repair.action_repair_start()
+        repair.action_force_availability()
         repair.action_repair_end()
         self.assertEqual(rma.qty_to_pay, 0.0)
         repair.action_repair_invoice_create()

--- a/rma_repair/views/rma_operation_view.xml
+++ b/rma_repair/views/rma_operation_view.xml
@@ -21,6 +21,7 @@
                 <group name="repair" string="Repair">
                     <field name="repair_location_id" />
                     <field name="repair_invoice_method" />
+                    <field name="repair_route_id" />
                 </group>
             </group>
             <field name="delivery_policy" position="after">

--- a/rma_repair/views/rma_order_line_view.xml
+++ b/rma_repair/views/rma_order_line_view.xml
@@ -13,7 +13,7 @@
                     class="oe_stat_button"
                     icon="fa-wrench"
                     groups="stock.group_stock_user"
-                    attrs="{'invisible':[('repair_count','=',0)]}"
+                    attrs="{'invisible': [('repair_count', '=', 0)]}"
                 >
                         <field
                         name="repair_count"
@@ -21,6 +21,20 @@
                         string="Repair Orders"
                     />
                 </button>
+                <button
+                    type="object"
+                    name="action_view_repair_transfers"
+                    class="oe_stat_button"
+                    icon="fa-truck"
+                    groups="stock.group_stock_user"
+                    attrs="{'invisible': [('repair_transfer_count', '=', 0)]}"
+                >
+                        <field
+                        name="repair_transfer_count"
+                        widget="statinfo"
+                        string="Repair Transfers"
+                    />
+                    </button>
             </div>
             <group name="quantities" position="inside">
                 <group attrs="{'invisible': [('repair_type', '=', 'no')]}">
@@ -51,13 +65,13 @@
                     name="%(action_rma_order_line_make_repair)d"
                     string="Create Repair Order"
                     class="oe_highlight"
-                    attrs="{'invisible':['|', '|', ('type', '!=', 'customer'), ('qty_to_repair', '=', 0), ('state', '!=', 'approved')]}"
+                    attrs="{'invisible':['|', '|', ('type', '!=', 'customer'), '|', ('qty_to_repair', '=', 0), ('qty_to_repair', '&lt;', 0), ('state', '!=', 'approved')]}"
                     type="action"
                 />
                 <button
                     name="%(action_rma_order_line_make_repair)d"
                     string="Create Repair Order"
-                    attrs="{'invisible':['|', '|', ('type', '!=', 'customer'), ('qty_to_repair', '!=', 0), ('state', '!=', 'approved')]}"
+                    attrs="{'invisible':['|', '|', ('type', '!=', 'customer'), ('qty_to_repair', '>', 0), ('state', '!=', 'approved')]}"
                     type="action"
                 />
             </header>

--- a/rma_repair/views/rma_order_view.xml
+++ b/rma_repair/views/rma_order_view.xml
@@ -21,6 +21,20 @@
                         string="Repair Orders"
                     />
                 </button>
+                <button
+                    type="object"
+                    name="action_view_repair_transfers"
+                    class="oe_stat_button"
+                    icon="fa-truck"
+                    groups="stock.group_stock_user"
+                    attrs="{'invisible': [('repair_transfer_count', '=', 0)]}"
+                >
+                        <field
+                        name="repair_transfer_count"
+                        widget="statinfo"
+                        string="Repair Transfers"
+                    />
+                    </button>
             </div>
             <xpath expr="//field[@name='rma_line_ids']/tree" position="inside">
                 <field name="repair_type" invisible="True" />

--- a/rma_repair/wizards/rma_order_line_make_repair.py
+++ b/rma_repair/wizards/rma_order_line_make_repair.py
@@ -62,9 +62,6 @@ class RmaLineMakeRepair(models.TransientModel):
                 item._run_procurement(
                     rma_line.operation_id.repair_route_id, repair.location_id
                 )
-                item._run_procurement(
-                    rma_line.operation_id.repair_route_id, rma_line.location_id
-                )
         return {
             "domain": [("id", "in", res)],
             "name": _("Repairs"),

--- a/rma_repair/wizards/rma_order_line_make_repair_view.xml
+++ b/rma_repair/wizards/rma_order_line_make_repair_view.xml
@@ -12,14 +12,23 @@
                  <group>
                      <field name="item_ids" nolabel="1" colspan="2">
                           <tree name="Details" editable="bottom" create="false">
-                              <field name="line_id" options="{'no_open': true}" />
-                              <field name="product_id" />
+                              <field
+                                name="line_id"
+                                force_save="1"
+                                options="{'no_open': true}"
+                            />
+                              <field name="product_id" force_save="1" />
                               <field name="product_qty" />
-                              <field name="product_uom_id" groups="uom.group_uom" />
-                              <field name="partner_id" />
+                              <field
+                                name="product_uom_id"
+                                force_save="1"
+                                groups="uom.group_uom"
+                            />
+                              <field name="partner_id" force_save="1" />
                               <field
                                 name="location_id"
                                 groups="stock.group_stock_multi_locations"
+                                force_save="1"
                             />
                               <field name="invoice_method" />
                           </tree>


### PR DESCRIPTION
When creating a Repair Order from RMA, if the repair location is not the same as the RMA location, no stock move was being created to move the product to the repair location. Now it creates an internal picking to supply the demand.

@ForgeFlow