### PR TITLE
[14.0][FIX] rma: outgoing moves and pickings

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -77,7 +77,10 @@ class RmaOrderLine(models.Model):
         for move in self.move_ids:
             first_usage = move._get_first_usage()
             last_usage = move._get_last_usage()
-            if first_usage == "internal" and last_usage != "internal":
+            if first_usage in ("internal", "production") and last_usage in (
+                "customer",
+                "supplier",
+            ):
                 moves |= move
             elif first_usage == "supplier" and last_usage == "customer":
                 moves |= moves
@@ -89,7 +92,10 @@ class RmaOrderLine(models.Model):
         for move in self.move_ids:
             first_usage = move._get_first_usage()
             last_usage = move._get_last_usage()
-            if first_usage in ("internal", "production") and last_usage != "internal":
+            if first_usage in ("internal", "production") and last_usage in (
+                "customer",
+                "supplier",
+            ):
                 pickings |= move.picking_id
             elif last_usage == "customer" and first_usage == "supplier":
                 pickings |= move.picking_id


### PR DESCRIPTION
When computing the outgoing moves, it were taking all the pickings that weren't going to internal. An internal move from WH/Stock to VirtualLocations/Scrap will be taked with this method. Now it takes all the moves going from an internal location to customer or supplier. (Also the dropshipping moves).

@ForgeFlow