### PR TITLE
[16.0][FIX] rma_req_approval_permission

### DIFF
--- a/rma/views/rma_order_line_view.xml
+++ b/rma/views/rma_order_line_view.xml
@@ -76,7 +76,7 @@
                         string="Approve"
                         attrs="{'invisible':[('state', '!=', 'to_approve')]}"
                         class="oe_highlight"
-                        groups="rma.group_rma_customer_user"
+                        groups="rma.group_rma_manager"
                     />
                         <button
                         name="action_rma_approve"


### PR DESCRIPTION
Fixing the fact that any internal user could approve a Customer/Supplier RMA. With this change, only the users who have RMA Manager access rights can perform this action. 