### PR TITLE
[16.0][FIX] rma : Do not cancel whole in/out picking when cancelling a rma line

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -666,10 +666,6 @@ class RmaOrderLine(models.Model):
             order.check_cancel()
             order.write({"state": "canceled"})
             order.move_ids._action_cancel()
-            shipments = order._get_in_pickings()
-            shipments |= order._get_out_pickings()
-            for ship in shipments:
-                ship.action_cancel()
         return True
 
     def _get_price_unit(self):


### PR DESCRIPTION
Hello,

There is an important problem with rma line  cancelation.
If you create a rma group, with multiple lines, then create a delivery for all the lines of the group, and then, cancel one line, the whole delivery is canceled. So the rest of the valid (not  canceled) lines won't be shipped (nor canceled)

This PR fixes this, I am not sure why it was done this way, so, reviews are welcome.

An additional problem IMO, is that in case of delivery with multiple steps (with pull rules involved), canceling the rma line only cancel the delivery and the previous steps remains pending.
Any idea to solve this easily ?
@DavidJForgeFlow @LoisRForgeFlow @JordiBForgeFlow 
