### PR TITLE
[14.0][FIX] rma: procurement origin

### DIFF
--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -779,6 +779,8 @@ class TestRma(common.SavepointCase):
         ).create({})
         wizard._create_picking()
         picking = self.rma_supplier_id.rma_line_ids._get_out_pickings()
+        partner = picking.partner_id
+        self.assertTrue(partner, "Partner is not defined or False")
         moves = picking.move_lines
         self.assertEqual(len(moves), 3, "Incorrect number of moves created")
 
@@ -898,6 +900,8 @@ class TestRma(common.SavepointCase):
         pickings = self.env["stock.picking"].browse(res["res_id"])
         self.assertEqual(len(pickings), 1, "Incorrect number of pickings created")
         picking_in = pickings[0]
+        partner = picking_in.partner_id
+        self.assertTrue(partner, "Partner is not defined or False")
         moves = picking_in.move_lines
         self.assertEqual(len(moves), 3, "Incorrect number of moves created")
 
@@ -1146,3 +1150,20 @@ class TestRma(common.SavepointCase):
         self.assertEqual(rma.qty_to_deliver, 0)
         self.assertEqual(rma.qty_delivered, 3)
         self.assertEqual(len(rma.move_ids), 4)
+
+    def test_09_supplier_rma_single_line(self):
+        rma_line_id = self.rma_supplier_id.rma_line_ids[0].id
+        wizard = self.rma_make_picking.with_context(
+            {
+                "active_ids": [rma_line_id],
+                "active_model": "rma.order.line",
+                "picking_type": "outgoing",
+                "active_id": 2,
+            }
+        ).create({})
+        wizard._create_picking()
+        picking = self.rma_supplier_id.rma_line_ids[0]._get_out_pickings()
+        partner = picking.partner_id
+        self.assertTrue(partner, "Partner is not defined or False")
+        moves = picking.move_lines
+        self.assertEqual(len(moves), 1, "Incorrect number of moves created")

--- a/rma/wizards/rma_make_picking.py
+++ b/rma/wizards/rma_make_picking.py
@@ -123,7 +123,7 @@ class RmaMakePicking(models.TransientModel):
         procurement_data = {
             "name": line.rma_id and line.rma_id.name or line.name,
             "group_id": group,
-            "origin": line.name,
+            "origin": group and group.name or line.name,
             "warehouse_id": warehouse,
             "date_planned": time.strftime(DT_FORMAT),
             "product_id": item.product_id,


### PR DESCRIPTION
In the current implementation of Odoo's `_assign_picking() `method in stock.move, there's a conditional check that looks at whether all the moves associated with a picking have the same partner_id and origin. If any move doesn't align with these conditions, the origin of the picking is set to False.

```
        if any(picking.partner_id.id != m.partner_id.id or
                picking.origin != m.origin for m in moves):
            # If a picking is found, we'll append `move` to its move list and thus its
            # `partner_id` and `ref` field will refer to multiple records. In this
            # case, we chose to  wipe them.
            picking.write({
                'partner_id': False,
                'origin': False,
            })
```

In the context of RMA  when we have multiple moves associated with a picking, each coming from a different RMA order line, we encounter a problem. Each move has its origin set as the name of the RMA orde line (`line.name`), so as soon as a second move from a different line is appended to the picking, the origin of the picking is wiped, because it doesn't match the origin of the first move.

In order to prevent the partner_id of the picking from being set to False when there are multiple associated moves, I propose that we change the origin of the procurement from the name of the RMA line to the name of the procurement group (`group.name`). This way, all moves associated with a picking will share the same origin, preserving the origin of the picking and ensuring it doesn't get inadvertently set to False.

@LoisRForgeFlow @AaronHForgeFlow 