### PR TITLE
[FIX] rma_scrap: no scrap if qty to scrap = 0.0

### DIFF
--- a/rma_scrap/models/stock_scrap.py
+++ b/rma_scrap/models/stock_scrap.py
@@ -1,7 +1,9 @@
 # Copyright 2022 ForgeFlow S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.html).
 
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import float_compare, float_is_zero
 
 
 class StockScrap(models.Model):
@@ -39,3 +41,55 @@ class StockScrap(models.Model):
         result["views"] = [(res and res.id or False, "form")]
         result["res_id"] = self.rma_line_id.id
         return result
+
+    def action_validate(self):
+        self.ensure_one()
+        if float_is_zero(
+            self.scrap_qty, precision_rounding=self.product_uom_id.rounding
+        ):
+            raise UserError(_("You can only enter positive quantities."))
+        if self.product_id.type != "product":
+            return self.do_scrap()
+        precision = self.env["decimal.precision"].precision_get(
+            "Product Unit of Measure"
+        )
+        available_qty = sum(
+            self.env["stock.quant"]
+            ._gather(
+                self.product_id,
+                self.location_id,
+                self.lot_id,
+                self.package_id,
+                self.owner_id,
+                strict=True,
+            )
+            .mapped("quantity")
+        )
+        scrap_qty = self.product_uom_id._compute_quantity(
+            self.scrap_qty, self.product_id.uom_id
+        )
+        if float_compare(available_qty, scrap_qty, precision_digits=precision) >= 0:
+            return self.do_scrap()
+        else:
+            ctx = dict(self.env.context)
+            ctx.update(
+                {
+                    "default_product_id": self.product_id.id,
+                    "default_location_id": self.location_id.id,
+                    "default_scrap_id": self.id,
+                    "default_quantity": scrap_qty,
+                    "default_product_uom_name": self.product_id.uom_name,
+                }
+            )
+            return {
+                "name": self.product_id.display_name
+                + _(": Insufficient Quantity To Scrap"),
+                "view_mode": "form",
+                "res_model": "stock.warn.insufficient.qty.scrap",
+                "view_id": self.env.ref(
+                    "stock.stock_warn_insufficient_qty_scrap_form_view"
+                ).id,
+                "type": "ir.actions.act_window",
+                "context": ctx,
+                "target": "new",
+            }

--- a/rma_scrap/tests/test_rma_scrap.py
+++ b/rma_scrap/tests/test_rma_scrap.py
@@ -102,8 +102,20 @@ class TestRmaScrap(common.SingleTransactionCase):
                 "active_id": 1,
             }
         ).create({})
-        wizard._create_picking()
+
+        self.assertEqual(rma.qty_to_receive, 1.00)
+        self.assertFalse(rma.qty_to_scrap)
+
+        action_picking = wizard.action_create_picking()
+        picking = self.env["stock.picking"].browse([action_picking["res_id"]])
+        picking.move_line_ids[0].qty_done = rma.qty_to_receive
+
+        picking.button_validate()
         rma._compute_qty_to_scrap()
+
+        self.assertFalse(rma.qty_to_receive)
+        self.assertEqual(rma.qty_received, 1.00)
+        self.assertEqual(rma.qty_to_scrap, 1.00)
         wizard = self.rma_make_scrap_wiz.with_context(
             {
                 "active_ids": rma.id,
@@ -129,6 +141,8 @@ class TestRmaScrap(common.SingleTransactionCase):
         scrap.action_validate()
         move = scrap.move_id
         self.assertEqual(move.product_id.id, self.product_1.id)
+        self.assertFalse(rma.qty_to_scrap)
+        self.assertEqual(rma.qty_scrap, 1.00)
 
     def test_02_rma_scrap_ordered(self):
         rma = self.rma_line_obj.create(
@@ -147,6 +161,11 @@ class TestRmaScrap(common.SingleTransactionCase):
         rma._onchange_operation_id()
         rma.action_rma_to_approve()
         rma._compute_qty_to_scrap()
+
+        self.assertEqual(rma.qty_to_receive, 1.00)
+        self.assertEqual(rma.qty_to_scrap, 1.00)
+        self.assertFalse(rma.qty_in_scrap)
+
         wizard = self.rma_make_scrap_wiz.with_context(
             {
                 "active_ids": rma.id,
@@ -169,4 +188,8 @@ class TestRmaScrap(common.SingleTransactionCase):
         scrap = self.env["stock.scrap"].browse([action["res_id"]])
         self.assertEqual(scrap.location_id.id, self.stock_rma_location.id)
         self.assertEqual(scrap.move_id.id, False)
-        self.assertTrue(scrap.action_validate())
+        self.assertEqual(rma.qty_in_scrap, 1.00)
+        res = scrap.action_validate()
+        scrap.do_scrap()
+        self.assertTrue(res)
+        self.assertEqual(rma.qty_scrap, 1.00)


### PR DESCRIPTION
After this fix, it is no longer possible to create a scrap with a quantity of 0.0. Additionally, the tests have been accordingly updated.