### PR TITLE
[14.0][REF] rma: change rules to route in warehouse

### DIFF
--- a/rma/models/rma_operation.py
+++ b/rma/models/rma_operation.py
@@ -12,7 +12,7 @@ class RmaOperation(models.Model):
     def _default_warehouse_id(self):
         company_id = self.env.user.company_id.id
         warehouse = self.env["stock.warehouse"].search(
-            [("company_id", "=", company_id)], limit=1
+            [("company_id", "=", company_id)], order="sequence asc", limit=1
         )
         return warehouse
 
@@ -24,13 +24,33 @@ class RmaOperation(models.Model):
     def _default_supplier_location_id(self):
         return self.env.ref("stock.stock_location_suppliers") or False
 
-    @api.model
-    def _default_routes(self):
+    @api.onchange("in_warehouse_id")
+    def onchange_warehouse_id(self):
         op_type = self.env.context.get("default_type")
         if op_type == "customer":
-            return self.env.ref("rma.route_rma_customer")
+            warehouse = self.in_warehouse_id
+            if not warehouse or not warehouse.rma_customer_pull_id:
+                return
+            self.in_route_id = warehouse.rma_customer_pull_id
+            self.out_route_id = warehouse.rma_customer_pull_id
         elif op_type == "supplier":
-            return self.env.ref("rma.route_rma_supplier")
+            warehouse = self.out_warehouse_id
+            if not warehouse or not warehouse.rma_supplier_pull_id:
+                return
+            self.in_route_id = warehouse.rma_supplier_pull_id
+            self.out_route_id = warehouse.rma_supplier_pull_id
+
+    @api.model
+    def _default_routes(self):
+        company_id = self.env.user.company_id.id
+        warehouse = self.env["stock.warehouse"].search(
+            [("company_id", "=", company_id)], limit=1
+        )
+        op_type = self.env.context.get("default_type")
+        if op_type == "customer":
+            return warehouse.rma_customer_pull_id.id
+        elif op_type == "supplier":
+            return warehouse.rma_supplier_pull_id.id
 
     name = fields.Char("Description", required=True)
     code = fields.Char("Code", required=True)

--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -24,11 +24,14 @@ class RmaOrderLine(models.Model):
     @api.model
     def _default_warehouse_id(self):
         rma_id = self.env.context.get("default_rma_id", False)
-        warehouse = self.env["stock.warehouse"]
+        company_id = self.env.user.company_id.id
+        warehouse = self.env["stock.warehouse"].search(
+            [("company_id", "=", company_id)], order="sequence asc", limit=1
+        )
         if rma_id:
             rma = self.env["rma.order"].browse(rma_id)
             warehouse = self.env["stock.warehouse"].search(
-                [("company_id", "=", rma.company_id.id)], limit=1
+                [("company_id", "=", rma.company_id.id)], order="sequence asc", limit=1
             )
         return warehouse
 

--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -582,7 +582,6 @@ class RmaOrderLine(models.Model):
                 operation.location_id.id
                 or operation.in_warehouse_id.lot_rma_id.id
                 or operation.out_warehouse_id.lot_rma_id.id
-                or warehouse.lot_rma_id.id
             ),
         }
         return data

--- a/rma/models/stock_warehouse.py
+++ b/rma/models/stock_warehouse.py
@@ -89,8 +89,8 @@ class StockWarehouse(models.Model):
                         if r_type:
                             r_type.active = False
                 # Unlink rules:
-                self.mapped("rma_customer_pull_id").unlink()
-                self.mapped("rma_supplier_pull_id").unlink()
+                self.mapped("rma_customer_pull_id").active = False
+                self.mapped("rma_supplier_pull_id").active = False
         return super(StockWarehouse, self).write(vals)
 
     def _create_rma_picking_types(self):

--- a/rma/models/stock_warehouse.py
+++ b/rma/models/stock_warehouse.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2017-20 ForgeFlow S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 
 
 class StockWarehouse(models.Model):
@@ -28,18 +28,21 @@ class StockWarehouse(models.Model):
         help="If set, it will create RMA location, picking types and routes "
         "for this warehouse.",
     )
-    rma_customer_in_pull_id = fields.Many2one(
-        comodel_name="stock.rule", string="RMA Customer In Rule"
+    rma_customer_pull_id = fields.Many2one(
+        comodel_name="stock.location.route",
+        string="RMA Customer Route",
     )
-    rma_customer_out_pull_id = fields.Many2one(
-        comodel_name="stock.rule", string="RMA Customer Out Rule"
+    rma_supplier_pull_id = fields.Many2one(
+        comodel_name="stock.location.route",
+        string="RMA Supplier Route",
     )
-    rma_supplier_in_pull_id = fields.Many2one(
-        comodel_name="stock.rule", string="RMA Supplier In Rule"
-    )
-    rma_supplier_out_pull_id = fields.Many2one(
-        comodel_name="stock.rule", string="RMA Supplier Out Rule"
-    )
+
+    @api.returns("self")
+    def _get_all_routes(self):
+        routes = super()._get_all_routes()
+        routes |= self.rma_customer_pull_id
+        routes |= self.rma_supplier_pull_id
+        return routes
 
     def _get_rma_types(self):
         return [
@@ -78,18 +81,16 @@ class StockWarehouse(models.Model):
                         for r_type in wh._get_rma_types():
                             if r_type:
                                 r_type.active = True
-                    # RMA rules:
-                    wh._create_or_update_rma_pull()
+                    # RMA routes:
+                    wh._create_rma_pull()
             else:
                 for wh in self:
                     for r_type in wh._get_rma_types():
                         if r_type:
                             r_type.active = False
                 # Unlink rules:
-                self.mapped("rma_customer_in_pull_id").unlink()
-                self.mapped("rma_customer_out_pull_id").unlink()
-                self.mapped("rma_supplier_in_pull_id").unlink()
-                self.mapped("rma_supplier_out_pull_id").unlink()
+                self.mapped("rma_customer_pull_id").unlink()
+                self.mapped("rma_supplier_pull_id").unlink()
         return super(StockWarehouse, self).write(vals)
 
     def _create_rma_picking_types(self):
@@ -175,90 +176,121 @@ class StockWarehouse(models.Model):
             )
         return True
 
-    def get_rma_rules_dict(self):
+    def get_rma_route_customer(self):
         self.ensure_one()
-        rma_rules = dict()
-        customer_loc, supplier_loc = self._get_partner_locations()
-        rma_rules["rma_customer_in"] = {
-            "name": self._format_rulename(self, customer_loc, self.lot_rma_id.name),
-            "action": "pull",
-            "warehouse_id": self.id,
-            "company_id": self.company_id.id,
-            "location_src_id": customer_loc.id,
-            "location_id": self.lot_rma_id.id,
-            "procure_method": "make_to_stock",
-            "route_id": self.env.ref("rma.route_rma_customer").id,
-            "picking_type_id": self.rma_cust_in_type_id.id,
-            "active": True,
-        }
-        rma_rules["rma_customer_out"] = {
-            "name": self._format_rulename(self, self.lot_rma_id, customer_loc.name),
-            "action": "pull",
-            "warehouse_id": self.id,
-            "company_id": self.company_id.id,
-            "location_src_id": self.lot_rma_id.id,
-            "location_id": customer_loc.id,
-            "procure_method": "make_to_stock",
-            "route_id": self.env.ref("rma.route_rma_customer").id,
-            "picking_type_id": self.rma_cust_out_type_id.id,
-            "active": True,
-        }
-        rma_rules["rma_supplier_in"] = {
-            "name": self._format_rulename(self, supplier_loc, self.lot_rma_id.name),
-            "action": "pull",
-            "warehouse_id": self.id,
-            "company_id": self.company_id.id,
-            "location_src_id": supplier_loc.id,
-            "location_id": self.lot_rma_id.id,
-            "procure_method": "make_to_stock",
-            "route_id": self.env.ref("rma.route_rma_supplier").id,
-            "picking_type_id": self.rma_sup_in_type_id.id,
-            "active": True,
-        }
-        rma_rules["rma_supplier_out"] = {
-            "name": self._format_rulename(self, self.lot_rma_id, supplier_loc.name),
-            "action": "pull",
-            "warehouse_id": self.id,
-            "company_id": self.company_id.id,
-            "location_src_id": self.lot_rma_id.id,
-            "location_id": supplier_loc.id,
-            "procure_method": "make_to_stock",
-            "route_id": self.env.ref("rma.route_rma_supplier").id,
-            "picking_type_id": self.rma_sup_out_type_id.id,
-            "active": True,
-        }
+        customer_loc, _ = self._get_partner_locations()
+        rma_rules = [
+            {
+                "name": self.name + ": Customer RMA",
+                "rma_selectable": True,
+                "rule_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self._format_rulename(
+                                self, customer_loc, self.lot_rma_id.name
+                            ),
+                            "action": "pull",
+                            "warehouse_id": self.id,
+                            "company_id": self.company_id.id,
+                            "location_src_id": customer_loc.id,
+                            "location_id": self.lot_rma_id.id,
+                            "procure_method": "make_to_stock",
+                            "picking_type_id": self.rma_cust_in_type_id.id,
+                            "active": True,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self._format_rulename(
+                                self, self.lot_rma_id, customer_loc.name
+                            ),
+                            "action": "pull",
+                            "warehouse_id": self.id,
+                            "company_id": self.company_id.id,
+                            "location_src_id": self.lot_rma_id.id,
+                            "location_id": customer_loc.id,
+                            "procure_method": "make_to_stock",
+                            "picking_type_id": self.rma_cust_out_type_id.id,
+                            "active": True,
+                        },
+                    ),
+                ],
+            }
+        ]
         return rma_rules
 
-    def _create_or_update_rma_pull(self):
-        rule_obj = self.env["stock.rule"]
+    def get_rma_route_supplier(self):
+        self.ensure_one()
+        _, supplier_loc = self._get_partner_locations()
+        rma_route = [
+            {
+                "name": self.name + ": Supplier RMA",
+                "rma_selectable": True,
+                "rule_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self._format_rulename(
+                                self, supplier_loc, self.lot_rma_id.name
+                            ),
+                            "action": "pull",
+                            "warehouse_id": self.id,
+                            "company_id": self.company_id.id,
+                            "location_src_id": supplier_loc.id,
+                            "location_id": self.lot_rma_id.id,
+                            "procure_method": "make_to_stock",
+                            "picking_type_id": self.rma_sup_in_type_id.id,
+                            "active": True,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self._format_rulename(
+                                self, self.lot_rma_id, supplier_loc.name
+                            ),
+                            "action": "pull",
+                            "warehouse_id": self.id,
+                            "company_id": self.company_id.id,
+                            "location_src_id": self.lot_rma_id.id,
+                            "location_id": supplier_loc.id,
+                            "procure_method": "make_to_stock",
+                            "picking_type_id": self.rma_sup_out_type_id.id,
+                            "active": True,
+                        },
+                    ),
+                ],
+            }
+        ]
+        return rma_route
+
+    def _create_rma_pull(self):
+        route_obj = self.env["stock.location.route"]
         for wh in self:
-            rules_dict = wh.get_rma_rules_dict()
-            if wh.rma_customer_in_pull_id:
-                wh.rma_customer_in_pull_id.write(rules_dict["rma_customer_in"])
-            else:
-                wh.rma_customer_in_pull_id = rule_obj.create(
-                    rules_dict["rma_customer_in"]
+            if not wh.rma_customer_pull_id:
+                wh.rma_customer_pull_id = (
+                    route_obj.create(self.get_rma_route_customer())
+                    if wh
+                    not in self.env.ref("rma.route_rma_customer").rule_ids.mapped(
+                        "warehouse_id"
+                    )
+                    else self.env.ref("rma.route_rma_customer")
                 )
 
-            if wh.rma_customer_out_pull_id:
-                wh.rma_customer_out_pull_id.write(rules_dict["rma_customer_out"])
-            else:
-                wh.rma_customer_out_pull_id = rule_obj.create(
-                    rules_dict["rma_customer_out"]
-                )
-
-            if wh.rma_supplier_in_pull_id:
-                wh.rma_supplier_in_pull_id.write(rules_dict["rma_supplier_in"])
-            else:
-                wh.rma_supplier_in_pull_id = rule_obj.create(
-                    rules_dict["rma_supplier_in"]
-                )
-
-            if wh.rma_supplier_out_pull_id:
-                wh.rma_supplier_out_pull_id.write(rules_dict["rma_supplier_out"])
-            else:
-                wh.rma_supplier_out_pull_id = rule_obj.create(
-                    rules_dict["rma_supplier_out"]
+            if not wh.rma_supplier_pull_id:
+                wh.rma_supplier_pull_id = (
+                    route_obj.create(self.get_rma_route_supplier())
+                    if wh
+                    not in self.env.ref("rma.route_rma_supplier").rule_ids.mapped(
+                        "warehouse_id"
+                    )
+                    else self.env.ref("rma.route_rma_supplier")
                 )
         return True
 

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -26,7 +26,6 @@ class TestRma(common.SavepointCase):
         cls.rma_cust_replace_op_id = cls.env.ref("rma.rma_operation_customer_replace")
         cls.rma_sup_replace_op_id = cls.env.ref("rma.rma_operation_supplier_replace")
         cls.rma_ds_replace_op_id = cls.env.ref("rma.rma_operation_ds_replace")
-        cls.customer_route = cls.env.ref("rma.route_rma_customer")
         cls.input_location = cls.env.ref("stock.stock_location_company")
         cls.output_location = cls.env.ref("stock.stock_location_output")
         cls.category = cls._create_product_category(
@@ -44,7 +43,10 @@ class TestRma(common.SavepointCase):
         cls.partner_id = cls.env.ref("base.res_partner_2")
         cls.stock_location = cls.env.ref("stock.stock_location_stock")
         cls.wh = cls.env.ref("stock.warehouse0")
+        cls.wh.rma_in_this_wh = False
+        cls.wh.rma_in_this_wh = True
         cls.stock_rma_location = cls.wh.lot_rma_id
+        cls.customer_route = cls.wh.rma_customer_pull_id
         cls.customer_location = cls.env.ref("stock.stock_location_customers")
         cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
         cls.product_uom_id = cls.env.ref("uom.product_uom_unit")
@@ -380,9 +382,7 @@ class TestRma(common.SavepointCase):
             # check assert if call reference_move_id onchange
             self.assertEqual(line.product_id, line.reference_move_id.product_id)
             self.assertEqual(line.product_qty, line.reference_move_id.product_uom_qty)
-            self.assertEqual(
-                line.location_id.location_id, line.reference_move_id.location_id
-            )
+            self.assertEqual(line.location_id, line.in_warehouse_id.lot_rma_id)
             self.assertEqual(line.origin, line.reference_move_id.picking_id.name)
             self.assertEqual(
                 line.delivery_address_id, line.reference_move_id.picking_partner_id
@@ -1087,8 +1087,10 @@ class TestRma(common.SavepointCase):
         """
         # Alter the customer RMA route to make it multi-step
         # Get rid of the duplicated rule
-        self.env.ref("rma.rule_rma_customer_out_pull").active = False
-        self.env.ref("rma.rule_rma_customer_in_pull").active = False
+        self.customer_route.rule_ids.active = False
+        # to be able to receive in in WH
+        self.wh.reception_steps = "two_steps"
+        self.wh.delivery_steps = "pick_ship"
         cust_in_pull_rule = self.customer_route.rule_ids.filtered(
             lambda r: r.location_id == self.stock_rma_location
         )
@@ -1103,7 +1105,7 @@ class TestRma(common.SavepointCase):
                 "name": "RMA->Output",
                 "action": "pull",
                 "warehouse_id": self.wh.id,
-                "location_src_id": self.env.ref("rma.location_rma").id,
+                "location_src_id": self.wh.lot_rma_id.id,
                 "location_id": self.output_location.id,
                 "procure_method": "make_to_stock",
                 "route_id": self.customer_route.id,
@@ -1140,7 +1142,7 @@ class TestRma(common.SavepointCase):
                 "action": "pull",
                 "warehouse_id": self.wh.id,
                 "location_src_id": self.input_location.id,
-                "location_id": self.env.ref("rma.location_rma").id,
+                "location_id": self.wh.lot_rma_id.id,
                 "procure_method": "make_to_order",
                 "route_id": self.customer_route.id,
                 "picking_type_id": self.env.ref("stock.picking_type_internal").id,

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -1112,7 +1112,31 @@ class TestRma(common.SavepointCase):
         )
         self.env["stock.rule"].create(
             {
-                "name": "Output->RMA",
+                "name": "Output->Customer",
+                "action": "pull",
+                "warehouse_id": self.wh.id,
+                "location_src_id": self.output_location.id,
+                "location_id": self.customer_location.id,
+                "procure_method": "make_to_order",
+                "route_id": self.customer_route.id,
+                "picking_type_id": self.env.ref("stock.picking_type_internal").id,
+            }
+        )
+        self.env["stock.rule"].create(
+            {
+                "name": "Customer->Input",
+                "action": "pull",
+                "warehouse_id": self.wh.id,
+                "location_src_id": self.customer_location.id,
+                "location_id": self.input_location.id,
+                "procure_method": "make_to_stock",
+                "route_id": self.customer_route.id,
+                "picking_type_id": self.env.ref("stock.picking_type_internal").id,
+            }
+        )
+        self.env["stock.rule"].create(
+            {
+                "name": "Input->RMA",
                 "action": "pull",
                 "warehouse_id": self.wh.id,
                 "location_src_id": self.input_location.id,

--- a/rma/views/stock_warehouse.xml
+++ b/rma/views/stock_warehouse.xml
@@ -10,6 +10,9 @@
             </xpath>
             <field name="resupply_wh_ids" position="after">
                 <field name="rma_in_this_wh" />
+                <field name="rma_customer_pull_id" />
+                <field name="rma_supplier_pull_id" />
+
             </field>
             <xpath expr="//field[@name='out_type_id']" position="after">
                 <field name="rma_cust_in_type_id" />

--- a/rma/wizards/rma_order_line_make_supplier_rma.py
+++ b/rma/wizards/rma_order_line_make_supplier_rma.py
@@ -135,7 +135,7 @@ class RmaLineMakeSupplierRma(models.TransientModel):
             "location_id": (
                 operation.location_id.id
                 or operation.in_warehouse_id.lot_rma_id.id
-                or warehouse.lot_rma_id.id
+                or item.line_id.in_warehouse_id.lot_rma_id.id
             ),
         }
         return data

--- a/rma_account/models/rma_order_line.py
+++ b/rma_account/models/rma_order_line.py
@@ -227,9 +227,7 @@ class RmaOrderLine(models.Model):
             "in_route_id": operation.in_route_id.id or route.id,
             "out_route_id": operation.out_route_id.id or route.id,
             "location_id": (
-                operation.location_id.id
-                or operation.in_warehouse_id.lot_rma_id.id
-                or warehouse.lot_rma_id.id
+                operation.location_id.id or operation.in_warehouse_id.lot_rma_id.id
             ),
         }
         return data

--- a/rma_account/tests/test_rma_stock_account.py
+++ b/rma_account/tests/test_rma_stock_account.py
@@ -273,7 +273,31 @@ class TestRmaStockAccount(TestRma):
         )
         self.env["stock.rule"].create(
             {
-                "name": "Output->RMA",
+                "name": "Output->Customer",
+                "action": "pull",
+                "warehouse_id": self.wh.id,
+                "location_src_id": self.output_location.id,
+                "location_id": self.customer_location.id,
+                "procure_method": "make_to_order",
+                "route_id": self.customer_route.id,
+                "picking_type_id": self.env.ref("stock.picking_type_internal").id,
+            }
+        )
+        self.env["stock.rule"].create(
+            {
+                "name": "Customer->Input",
+                "action": "pull",
+                "warehouse_id": self.wh.id,
+                "location_src_id": self.customer_location.id,
+                "location_id": self.input_location.id,
+                "procure_method": "make_to_stock",
+                "route_id": self.customer_route.id,
+                "picking_type_id": self.env.ref("stock.picking_type_internal").id,
+            }
+        )
+        self.env["stock.rule"].create(
+            {
+                "name": "Input->RMA",
                 "action": "pull",
                 "warehouse_id": self.wh.id,
                 "location_src_id": self.input_location.id,

--- a/rma_account/wizards/rma_add_account_move.py
+++ b/rma_account/wizards/rma_add_account_move.py
@@ -100,9 +100,7 @@ class RmaAddAccountMove(models.TransientModel):
             "in_route_id": operation.in_route_id.id or route.id,
             "out_route_id": operation.out_route_id.id or route.id,
             "location_id": (
-                operation.location_id.id
-                or operation.in_warehouse_id.lot_rma_id.id
-                or warehouse.lot_rma_id.id
+                operation.location_id.id or operation.in_warehouse_id.lot_rma_id.id
             ),
         }
         return data

--- a/rma_purchase/models/rma_order_line.py
+++ b/rma_purchase/models/rma_order_line.py
@@ -172,9 +172,7 @@ class RmaOrderLine(models.Model):
             "receipt_policy": operation.receipt_policy,
             "currency_id": line.currency_id.id,
             "location_id": (
-                operation.location_id.id
-                or operation.in_warehouse_id.lot_rma_id.id
-                or warehouse.lot_rma_id.id
+                operation.location_id.id or operation.in_warehouse_id.lot_rma_id.id
             ),
             "refund_policy": operation.refund_policy,
             "delivery_policy": operation.delivery_policy,

--- a/rma_purchase/wizards/rma_add_purchase.py
+++ b/rma_purchase/wizards/rma_add_purchase.py
@@ -97,9 +97,7 @@ class RmaAddPurchase(models.TransientModel):
             "out_route_id": operation.out_route_id.id or route,
             "receipt_policy": operation.receipt_policy,
             "location_id": (
-                operation.location_id.id
-                or operation.in_warehouse_id.lot_rma_id.id
-                or warehouse.lot_rma_id.id
+                operation.location_id.id or operation.in_warehouse_id.lot_rma_id.id
             ),
             "refund_policy": operation.refund_policy,
             "delivery_policy": operation.delivery_policy,

--- a/rma_sale/models/rma_order_line.py
+++ b/rma_sale/models/rma_order_line.py
@@ -160,9 +160,7 @@ class RmaOrderLine(models.Model):
             "receipt_policy": operation.receipt_policy,
             "currency_id": line.currency_id.id,
             "location_id": (
-                operation.location_id.id
-                or operation.in_warehouse_id.lot_rma_id.id
-                or warehouse.lot_rma_id.id
+                operation.location_id.id or operation.in_warehouse_id.lot_rma_id.id
             ),
             "refund_policy": operation.refund_policy,
             "delivery_policy": operation.delivery_policy,


### PR DESCRIPTION
The stock.rule fields are not used anywhere on rma. It's only usability is automatically setting the rules when setting a new warehouse with a RMA system. However, these rules are created by default in the main warehouse by the data. 
I propose to change the rules for routes to keep a good track of the RMA routes in warehouses and avoid duplicates.

@ForgeFlow 