### PR TITLE
[16.0][FIX] rma: inventory user by default should not see RMAs

### DIFF
--- a/rma/security/rma.xml
+++ b/rma/security/rma.xml
@@ -45,14 +45,6 @@
             <field name="implied_ids" eval="[(4, ref('group_rma_manager'))]" />
         </record>
 
-        <record id="stock.group_stock_user" model="res.groups">
-            <field
-            name="implied_ids"
-            eval="[(4, ref('group_rma_customer_user')),
-                          (4, ref('group_rma_supplier_user'))]"
-        />
-        </record>
-
         <record model="ir.rule" id="rma_order_rule">
           <field name="name">rma order multi-company</field>
           <field


### PR DESCRIPTION
If you are stock user  you may no need access to RMAs