### PR TITLE
[16][FIX] Delete rma_picking_wizard_item on cascade to avoid failure

### DIFF
--- a/rma/wizards/rma_make_picking.py
+++ b/rma/wizards/rma_make_picking.py
@@ -264,7 +264,9 @@ class RmaMakePickingItem(models.TransientModel):
     _name = "rma_make_picking.wizard.item"
     _description = "Items to receive"
 
-    wiz_id = fields.Many2one("rma_make_picking.wizard", string="Wizard", required=True)
+    wiz_id = fields.Many2one(
+        "rma_make_picking.wizard", string="Wizard", required=True, ondelete="cascade"
+    )
     line_id = fields.Many2one(
         "rma.order.line", string="RMA order Line", ondelete="cascade"
     )


### PR DESCRIPTION
Hello,

This small fixes an error on transient model cleaning : 
ForeignKeyViolation

ERREUR:  UPDATE ou DELETE sur la table « rma_make_picking_wizard » viole la contrainte de clé étrangère « rma_make_picking_wizard_item_wiz_id_fkey » de la table « rma_make_picking_wizard_item »
DETAIL:  La clé (id)=(8594) est toujours référencée à partir de la table « rma_make_picking_wizard_item ».


@AaronHForgeFlow 