### PR TITLE
[16][IMP] Remove deprecated domain from onchange method and put it in field view

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -730,7 +730,7 @@ class RmaOrderLine(models.Model):
             )
         if self.lot_id.product_id != self.product_id:
             self.lot_id = False
-        return {"domain": {"lot_id": [("product_id", "=", self.product_id.id)]}}
+        return result
 
     @api.onchange("operation_id")
     def _onchange_operation_id(self):

--- a/rma/views/rma_order_line_view.xml
+++ b/rma/views/rma_order_line_view.xml
@@ -203,6 +203,7 @@
                                 groups="stock.group_production_lot"
                                 attrs="{'required': [('product_tracking', 'in', ('serial', 'lot'))]}"
                                 context="{'default_product_id': product_id,}"
+                                domain="[('product_id', '=', product_id)]"
                             />
                                 <field name="under_warranty" />
                             </group>


### PR DESCRIPTION
Domain in onchange have been deprecated for a while and it generates this kind of warning : 
onchange method RmaOrderLine._onchange_product_id returned a domain, this is deprecated

Also, it is not perfect, because it does not apply in case there is no change on the product. (If I open an existing rma order line with a product, I can choose any lot, because the onchange was not played.

And there is already an xml domain in an other `rma.order.line view` : https://github.com/ForgeFlow/stock-rma/blob/16.0/rma/views/rma_order_view.xml#L195

So I don't see any reason not to remove this onchange domain, unless I am missing something ?

@AaronHForgeFlow FYI 