### PR TITLE
[14.0][FIX] rma_sale: Error when cancelling rma.order.line without sale order lines

### DIFF
--- a/rma_sale/models/rma_order_line.py
+++ b/rma_sale/models/rma_order_line.py
@@ -216,7 +216,7 @@ class RmaOrderLine(models.Model):
 
     def action_rma_cancel(self):
         res = super().action_rma_cancel()
-        for line in self:
+        for line in self.filtered("sale_line_ids"):
             line.sale_line_ids.mapped("order_id").action_cancel()
         return res
 


### PR DESCRIPTION
There is an error when trying to cancel a rma.order.line that has sale order lines associated.