### PR TITLE
[16] rma_sale : Always create rma line from sale line using stock move lines

### DIFF
--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -65,7 +65,10 @@ class TestRmaSale(common.SingleTransactionCase):
                 "pricelist_id": cls.env.ref("product.list0").id,
             }
         )
-
+        cls.so.action_confirm()
+        for move in cls.so.picking_ids.move_ids:
+            move.write({"quantity_done": move.product_uom_qty})
+        cls.so.picking_ids._action_done()
         # Create RMA group and operation:
         cls.rma_group = cls.rma_obj.create({"partner_id": customer1.id})
         cls.operation_1 = cls.rma_op_obj.create(


### PR DESCRIPTION
This way, we have the same way to create the rma lines, wether the tracking is active on the product or not.
Also and mainly, it allows to create rma lines for the component of a KIT sale order line instead of the kit.
When something is sent as a kit, the rma concerns usually only a part of it.

Maybe I could/should make it an option in the module rma_sale_mrp, so one could choose if the add from sale wizard create a line for the kit of for the components. There is a small hook `_create_from_move_line` which can be used for this purpose.

The main consequences of this PR then : 
- In case of kit used in sale order line, the "add from sale" wizard will generate one rma line per components (instead of one rma line for the kit)
- For a normal (not kit) product, with no tracking management, the quantity of the rma line will come from the done stock move line instead of the sale line (same way is is already for the normal (no kit) product with tracking management.

Please, let me know what you think @JordiBForgeFlow @AaronHForgeFlow 