### PR TITLE
[15.0][IMP] rma: add rma_line_id to stock.move views

### DIFF
--- a/rma/views/stock_view.xml
+++ b/rma/views/stock_view.xml
@@ -13,6 +13,39 @@
         </field>
     </record>
 
+    <record id="view_move_tree" model="ir.ui.view">
+        <field name="name">stock.move.tree - rma_line_id</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_move_tree" />
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field
+                    name="rma_line_id"
+                    optional="hide"
+                    attrs="{'invisible': [('rma_line_id', '=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_picking_form" model="ir.ui.view">
+        <field name="name">stock.picking.form.inherit</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//page[@name='operations']/field[@name='move_ids_without_package']/tree"
+                position="inside"
+            >
+                <field
+                    name="rma_line_id"
+                    optional="hide"
+                    attrs="{'invisible': [('rma_line_id', '=', False)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+
     <record id="stock_location_route_form_view_inherit_rma_stock" model="ir.ui.view">
         <field name="name">stock.location.route.form</field>
         <field name="inherit_id" ref="stock.stock_location_route_form_view" />


### PR DESCRIPTION
When looking at stock moves created from a rma group, it may be confusing knowing who's move is for which RMA line. This improvement should avoid these confusions.

Forward port of #498 

@ForgeFlow