### PR TITLE
[16.0][FIX] rma_repair, add rma_put_away as dependency

### DIFF
--- a/rma_repair/__manifest__.py
+++ b/rma_repair/__manifest__.py
@@ -8,7 +8,7 @@
     "summary": "Links RMA with Repairs.",
     "author": "ForgeFlow",
     "website": "https://github.com/ForgeFlow/stock-rma",
-    "depends": ["rma_account", "repair"],
+    "depends": ["rma_account", "repair", "rma_put_away"],
     "data": [
         "security/ir.model.access.csv",
         "views/rma_order_view.xml",


### PR DESCRIPTION
This line raise error when dependency is not installed

https://github.com/ForgeFlow/stock-rma/blob/16.0/rma_repair/models/rma_order.py#L19