### PR TITLE
[16.0][FIX] rma_account: fiscal_position_id is a computed field

### DIFF
--- a/rma_account/wizards/rma_refund.py
+++ b/rma_account/wizards/rma_refund.py
@@ -172,6 +172,8 @@ class RmaRefund(models.TransientModel):
             "date": wizard.date,
             "invoice_date": wizard.date_invoice,
             "partner_id": rma_line.invoice_address_id.id or rma_line.partner_id.id,
+            "partner_shipping_id": rma_line.delivery_address_id.id
+            or rma_line.partner_id.id,
             "invoice_line_ids": [
                 (0, None, self.prepare_refund_line(item)) for item in self.item_ids
             ],

--- a/rma_account/wizards/rma_refund.py
+++ b/rma_account/wizards/rma_refund.py
@@ -167,7 +167,6 @@ class RmaRefund(models.TransientModel):
             "ref": ref,
             "move_type": "in_refund" if rma_line.type == "supplier" else "out_refund",
             "journal_id": journal.id,
-            "fiscal_position_id": rma_line.partner_id.property_account_position_id.id,
             "state": "draft",
             "currency_id": self._get_refund_currency(rma_line).id,
             "date": wizard.date,


### PR DESCRIPTION
In v16, fiscal_position_id is a computed field, so if we set up the field in the refund creation we are overriding the computed value