### PR TITLE
[FIX] rma_sale: fix _get_price_unit to handle dropship cases

### DIFF
--- a/rma_sale/models/rma_order_line.py
+++ b/rma_sale/models/rma_order_line.py
@@ -232,7 +232,13 @@ class RmaOrderLine(models.Model):
                 and x.location_dest_id.usage == "customer"
             )
             if moves:
-                layers = moves.sudo().mapped("stock_valuation_layer_ids")
+                # We take negative valuation layers, as are to customers,
+                # and we handle dropship cases where will have negative and positive layers
+                layers = (
+                    moves.sudo()
+                    .mapped("stock_valuation_layer_ids")
+                    .filtered(lambda layer: layer.quantity < 0 and layer.value < 0)
+                )
                 if layers:
                     price_unit = sum(layers.mapped("value")) / sum(
                         layers.mapped("quantity")


### PR DESCRIPTION
Take negative valuation layers, as are to customers, and we handle dropship cases where will have negative and positive layers.
Up to now with dropship orders, sums from valuation layers were 0 and div by 0 error was raised.