### PR TITLE
[16] rma : add index on stock_move.rma_line_id

### DIFF
--- a/rma/models/stock_move.py
+++ b/rma/models/stock_move.py
@@ -8,7 +8,7 @@ class StockMove(models.Model):
     _inherit = "stock.move"
 
     rma_line_id = fields.Many2one(
-        "rma.order.line", string="RMA line", ondelete="restrict"
+        "rma.order.line", string="RMA line", ondelete="restrict", index="btree_not_null"
     )
 
     @api.model_create_multi


### PR DESCRIPTION
In a database with a lot of stock it helps a lot.
The one2many `rma.order.line.move_ids` for instance trigger a search on the this field.

@AaronHForgeFlow 