### PR TITLE
[16.0][IMP] rma, add feature to require origin field in rma approval process

### DIFF
--- a/rma/models/rma_operation.py
+++ b/rma/models/rma_operation.py
@@ -94,3 +94,7 @@ class RmaOperation(models.Model):
         required=True,
         default=lambda self: self.env.user.company_id,
     )
+    require_origin_field_filled = fields.Boolean(
+        default=False,
+        help="RMA document can't be continue in process if at least one origin field is filled",
+    )

--- a/rma/views/rma_operation_view.xml
+++ b/rma/views/rma_operation_view.xml
@@ -41,6 +41,7 @@
                         <group name="policies" string="Policies">
                             <field name="receipt_policy" />
                             <field name="delivery_policy" />
+                            <field name="require_origin_field_filled" />
                         </group>
                         <group name="inbound" string="Inbound">
                             <field name="in_route_id" />

--- a/rma_account/models/rma_order_line.py
+++ b/rma_account/models/rma_order_line.py
@@ -130,6 +130,11 @@ class RmaOrderLine(models.Model):
         ondelete="restrict",
     )
 
+    @api.model
+    def _origin_fields(self):
+        res = super()._origin_fields()
+        return res + ["account_move_line_id"]
+
     @api.depends("partner_id")
     def _compute_commercial_partner_id(self):
         for rma_line in self:

--- a/rma_purchase/models/rma_order_line.py
+++ b/rma_purchase/models/rma_order_line.py
@@ -88,6 +88,11 @@ class RmaOrderLine(models.Model):
         compute="_compute_qty_purchase",
     )
 
+    @api.model
+    def _origin_fields(self):
+        res = super()._origin_fields()
+        return res + ["purchase_order_line_id"]
+
     @api.onchange("product_id", "partner_id")
     def _onchange_product_id(self):
         """Domain for purchase_order_line_id is computed here to make

--- a/rma_sale/models/rma_order_line.py
+++ b/rma_sale/models/rma_order_line.py
@@ -82,6 +82,11 @@ class RmaOrderLine(models.Model):
     )
     sales_count = fields.Integer(compute="_compute_sales_count", string="# of Sales")
 
+    @api.model
+    def _origin_fields(self):
+        res = super()._origin_fields()
+        return res + ["sale_line_id"]
+
     @api.onchange("product_id", "partner_id")
     def _onchange_product_id(self):
         """Domain for sale_line_id is computed here to make it dynamic."""


### PR DESCRIPTION
RMA document can be processed without an origin field filled, to keep behavior I added the feature at operation level by default as False, once an operation activate this feature, at least one field should be filled to continue in approval process of document