### PR TITLE
[16.0][FIX] rma: _check_move_partner compare with RMA commercial partner 

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -622,7 +622,8 @@ class RmaOrderLine(models.Model):
         for rec in self:
             if (
                 rec.reference_move_id
-                and rec.reference_move_id.picking_id.partner_id != rec.partner_id
+                and rec.reference_move_id.picking_id.partner_id.commercial_partner_id
+                != rec.partner_id.commercial_partner_id
             ):
                 raise ValidationError(
                     _(


### PR DESCRIPTION
When an origin move is selected in an RMA, make the check if the picking address is equal to the delivery address from the RMA customer, instead of the customer address.