### PR TITLE
[16][FIX] rma: make date_rma stored once again on rma_order

### DIFF
--- a/rma/models/rma_order.py
+++ b/rma/models/rma_order.py
@@ -89,6 +89,7 @@ class RmaOrder(models.Model):
         string="Order Date",
         index=True,
         default=lambda self: self._default_date_rma(),
+        store=True,
     )
     partner_id = fields.Many2one(
         comodel_name="res.partner", string="Partner", required=True


### PR DESCRIPTION
It became unstored in this PR https://github.com/ForgeFlow/stock-rma/pull/443
But I think it was not intentional since there is an index, a default... The description of the compute method says we want to keep its own value if date of the lines have a different date, which is not possible if the field is not stored.
Also, the field is in the "group by" view and fail, because we can't group by this not stored field.