### PR TITLE
[16][IMP] Display product display name on incoming/outgoing stock move instead of rma ref

### DIFF
--- a/rma/wizards/rma_make_picking.py
+++ b/rma/wizards/rma_make_picking.py
@@ -125,7 +125,7 @@ class RmaMakePicking(models.TransientModel):
         if not warehouse:
             raise ValidationError(_("No warehouse specified"))
         procurement_data = {
-            "name": line.rma_id and line.rma_id.name or line.name,
+            "name": line.product_id.display_name,
             "group_id": group,
             "origin": group and group.name or line.name,
             "warehouse_id": warehouse,
@@ -169,7 +169,7 @@ class RmaMakePicking(models.TransientModel):
                 qty,
                 item.line_id.product_id.product_tmpl_id.uom_id,
                 values.get("location_id"),
-                values.get("origin"),
+                values.get("name"),
                 values.get("origin"),
                 self.env.company,
                 values,


### PR DESCRIPTION
It  seems more consistent to put product's display name in `stock.move` name rather than a RMA reference because it is what is done in case of sale order : https://github.com/OCA/OCB/blob/16.0/addons/sale_stock/models/sale_order_line.py#L356
Also, we already have the origin field to pass the RMA ref.

I'd like your opinion on this one if possible @AaronHForgeFlow @DavidJForgeFlow 