### PR TITLE
[REF] Force reservation of rma lot only for reception of the current rma lines processed

### DIFF
--- a/rma/wizards/rma_make_picking.py
+++ b/rma/wizards/rma_make_picking.py
@@ -203,9 +203,57 @@ class RmaMakePicking(models.TransientModel):
             procurements.extend(procurement)
         return procurements
 
+    def _force_reservation_specific_lot(self, pickings, picking_type):
+        move_line_model = self.env["stock.move.line"]
+        # Force the reservation of the RMA specific lot for incoming shipments.
+        # FIXME: still needs fixing, not reserving appropriate serials.
+        if picking_type == "incoming":
+            rma_line_candidates = self.item_ids.line_id
+            for move in pickings.move_ids.filtered(
+                lambda x: x.state not in ("draft", "cancel", "done", "waiting")
+                and x.rma_line_id
+                and x.rma_line_id in rma_line_candidates
+                and x.product_id.tracking in ("lot", "serial")
+                and x.rma_line_id.lot_id
+            ):
+                # Force the reservation of the RMA specific lot for incoming shipments.
+                move.move_line_ids.unlink()
+                if move.product_id.tracking == "serial":
+                    move.write(
+                        {
+                            "lot_ids": [(6, 0, move.rma_line_id.lot_id.ids)],
+                        }
+                    )
+                    quants = self.env["stock.quant"]._gather(
+                        move.product_id,
+                        move.location_id,
+                        lot_id=move.rma_line_id.lot_id,
+                    )
+                    move.move_line_ids.write(
+                        {
+                            "reserved_uom_qty": 1,
+                            "qty_done": 0,
+                            "package_id": len(quants) == 1 and quants.package_id.id,
+                        }
+                    )
+                elif move.product_id.tracking == "lot":
+                    qty = self.item_ids.filtered(
+                        lambda x: x.line_id.id == move.rma_line_id.id
+                    ).qty_to_receive
+                    move_line_data = move._prepare_move_line_vals()
+                    move_line_data.update(
+                        {
+                            "lot_id": move.rma_line_id.lot_id.id,
+                            "product_uom_id": move.product_id.uom_id.id,
+                            "qty_done": 0,
+                            "reserved_uom_qty": qty,
+                        }
+                    )
+                    move_line_model.create(move_line_data)
+                move.with_context(force_no_bypass_reservation=True)._action_assign()
+
     def action_create_picking(self):
         self._create_picking()
-        move_line_model = self.env["stock.move.line"]
         picking_type = self.env.context.get("picking_type")
         if picking_type == "outgoing":
             pickings = self.mapped("item_ids.line_id")._get_out_pickings()
@@ -213,52 +261,7 @@ class RmaMakePicking(models.TransientModel):
         else:
             pickings = self.mapped("item_ids.line_id")._get_in_pickings()
             action = self.item_ids.line_id.action_view_in_shipments()
-        # Force the reservation of the RMA specific lot for incoming shipments.
-        # FIXME: still needs fixing, not reserving appropriate serials.
-        for move in pickings.move_ids.filtered(
-            lambda x: x.state not in ("draft", "cancel", "done", "waiting")
-            and x.rma_line_id
-            and x.product_id.tracking in ("lot", "serial")
-            and x.rma_line_id.lot_id
-        ):
-            # Force the reservation of the RMA specific lot for incoming shipments.
-            move.move_line_ids.unlink()
-            if move.product_id.tracking == "serial":
-                move.write(
-                    {
-                        "lot_ids": [(6, 0, move.rma_line_id.lot_id.ids)],
-                    }
-                )
-                quants = self.env["stock.quant"]._gather(
-                    move.product_id, move.location_id, lot_id=move.rma_line_id.lot_id
-                )
-                move.move_line_ids.write(
-                    {
-                        "reserved_uom_qty": 1 if picking_type == "incoming" else 0,
-                        "qty_done": 0,
-                        "package_id": len(quants) == 1 and quants.package_id.id,
-                    }
-                )
-            elif move.product_id.tracking == "lot":
-                if picking_type == "incoming":
-                    qty = self.item_ids.filtered(
-                        lambda x: x.line_id.id == move.rma_line_id.id
-                    ).qty_to_receive
-                else:
-                    qty = self.item_ids.filtered(
-                        lambda x: x.line_id.id == move.rma_line_id.id
-                    ).qty_to_deliver
-                move_line_data = move._prepare_move_line_vals()
-                move_line_data.update(
-                    {
-                        "lot_id": move.rma_line_id.lot_id.id,
-                        "product_uom_id": move.product_id.uom_id.id,
-                        "qty_done": 0,
-                        "reserved_uom_qty": qty if picking_type == "incoming" else 0,
-                    }
-                )
-                move_line_model.create(move_line_data)
-            pickings.with_context(force_no_bypass_reservation=True).action_assign()
+        self._force_reservation_specific_lot(pickings, picking_type)
         return action
 
     def action_cancel(self):


### PR DESCRIPTION
I try a first refactore of this part that I don't fully understand.

I just see : `Force the reservation of the RMA specific lot for incoming shipments.`
And I do not understand how the current code help us with delivery, so I removed it.

Also, I try to fix the following bug : 
1) Create rma group with 2 lines. the 2 lines are related to products managed with lot (not serial number)
2) Run the wizard to create the reception of the first line. => This code is ran forcing the reservation of the rma lot for the reception.
3) Run the wizard to create the reception of the second line => The reservation of the previous line is lost.
It happens because all reservations `stock.move.line` of the picking (which group both lines) were deleted + the `reserved_uom_qty` is set only for the currently processed rma line since the quantity comes from the wizard items.

I propose this fix but I do believe all this should be removed and we should depend on OCA module `stock_restrict_lot`
https://github.com/OCA/stock-logistics-workflow/tree/16.0/stock_restrict_lot

IMO we should : 
- Depend on stock_restrict_lot
- Add a field on rma_operation or something, only visible when there is a delivery policy like `force_received_lot_for_shipping` or something.
- When creating the reception, the restrict_lot_id should be filled with `rma.order.line`'s `lot_id` field. (same behavior as today as far as I understand)
- When creating the delivery, if the flag `force_received_lot_for_shipping` is set on operation : the restrict_lot_id should be filled with `rma.order.line`'s `lot_id` field, else, keep empty.

Indeed, if there is a RMA on a specific lot, we expect this lot in the reception. But we possibly want to ship another one as a replacement, I don't believe it should (always) be restricted.

I'd appreciate any information/feedback to better understand  this part and if it is possible to switch toward `stock_restrict_lot` module. If not in v16, would be fine to have this for v18 at least.

I set this to draft as it is more a base for discussion for now...

@AaronHForgeFlow @DavidJForgeFlow I always ping you but if there are other person to ping I can change !

Edit : I also put this reservation logic in a separated method to be easily overridable... or simply totally silent the method.