### PR TITLE
[16][IMP] Manage quantities correctly in case of kit in RMA

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -108,28 +108,37 @@ class RmaOrderLine(models.Model):
             pickings = line._get_out_pickings()
             line.out_shipment_count = len(pickings)
 
+    def _get_rma_quantity_from_moves(self, moves):
+        self.ensure_one()
+        uom_obj = self.env["uom.uom"]
+        qty = 0.0
+        for move in moves:
+            if move.state == "done":
+                qty += uom_obj._compute_quantity(
+                    move.product_uom_qty, self.uom_id
+                )
+            else:
+                qty += uom_obj._compute_quantity(
+                    move.product_uom_qty, self.uom_id
+                )
+        return qty
+
     def _get_rma_move_qty(self, states, direction="in"):
         for rec in self:
-            product_obj = self.env["uom.uom"]
             qty = 0.0
             if direction == "in":
                 moves = rec._get_in_moves()
             else:
                 moves = rec._get_out_moves()
-            for move in moves.filtered(lambda m: m.state in states):
-                # If the move is part of a chain don't count it
-                if direction == "out" and move.move_orig_ids:
-                    continue
-                elif direction == "in" and move.move_dest_ids:
-                    continue
-                if move.state == "done":
-                    qty += product_obj._compute_quantity(
-                        move.product_uom_qty, rec.uom_id
-                    )
-                else:
-                    qty += product_obj._compute_quantity(
-                        move.product_uom_qty, rec.uom_id
-                    )
+            if direction == "out":
+                moves = moves.filtered(
+                    lambda move: not move.move_orig_ids and move.state in states
+                )
+            elif direction == "in":
+                moves = moves.filtered(
+                    lambda move: not move.move_dest_ids and move.state in states
+                )
+            qty = rec._get_rma_quantity_from_moves(moves)
             return qty
 
     @api.depends(

--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -132,7 +132,7 @@ class RmaOrderLine(models.Model):
                 moves = rec._get_out_moves()
             if direction == "out":
                 moves = moves.filtered(
-                    lambda move: not move.move_orig_ids and move.state in states
+                    lambda move: not move.move_dest_ids and move.state in states
                 )
             elif direction == "in":
                 moves = moves.filtered(

--- a/rma_sale_mrp/models/rma_order_line.py
+++ b/rma_sale_mrp/models/rma_order_line.py
@@ -39,3 +39,32 @@ class RmaOrderLine(models.Model):
         else:
             price_unit = super(RmaOrderLine, self)._get_price_unit()
         return price_unit
+
+    def _get_rma_quantity_from_moves(self, moves):
+        self.ensure_one()
+        boms = moves.bom_line_id.bom_id
+        relevant_bom = boms.filtered(
+            lambda b: b.type == "phantom"
+            and (
+                b.product_id == self.product_id
+                or (
+                    b.product_tmpl_id == self.product_id.product_tmpl_id
+                    and not b.product_id
+                )
+            )
+        )
+        if relevant_bom:
+            # moves are already filtered and we never have return here
+            filters = {
+                "incoming_moves": lambda m: True,
+                "outgoing_moves": lambda m: False,
+            }
+            order_qty = self.uom_id._compute_quantity(
+                self.product_qty, relevant_bom.product_uom_id
+            )
+            qty = moves._compute_kit_quantities(
+                self.product_id, order_qty, relevant_bom, filters
+            )
+        else:
+            qty = super()._get_rma_quantity_from_moves(moves)
+        return qty


### PR DESCRIPTION
I need to manage kit (phantom bom) sometimes in my RMA.
in `rma_sale_mrp`, there is already an option at company level allowing to add a rma line with the kit of multiple rma lines with the component, when creating the rma line from a sale order line.

But the to receive/deliver quantity are not managed for this kind of product.

This PR aims to solve it, at least for basic cases.
