### PR TITLE
[16][FIX] Exclude incoming/outgoing quantity from to receive / to deliver quantities

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -77,7 +77,7 @@ class RmaOrderLine(models.Model):
         for move in self.move_ids:
             first_usage = move._get_first_usage()
             last_usage = move._get_last_usage()
-            if first_usage == "internal" and last_usage != "internal":
+            if first_usage in ("internal", "production") and last_usage != "internal":
                 moves |= move
             elif first_usage == "supplier" and last_usage == "customer":
                 moves |= moves
@@ -132,14 +132,20 @@ class RmaOrderLine(models.Model):
         "receipt_policy",
         "product_qty",
         "type",
+        "qty_incoming",
+        "qty_delivered",
     )
     def _compute_qty_to_receive(self):
         for rec in self:
             rec.qty_to_receive = 0.0
             if rec.receipt_policy == "ordered":
-                rec.qty_to_receive = rec.product_qty - rec.qty_received
+                rec.qty_to_receive = (
+                    rec.product_qty - rec.qty_received - rec.qty_incoming
+                )
             elif rec.receipt_policy == "delivered":
-                rec.qty_to_receive = rec.qty_delivered - rec.qty_received
+                rec.qty_to_receive = (
+                    rec.qty_delivered - rec.qty_received - rec.qty_incoming
+                )
 
     @api.depends(
         "move_ids",
@@ -149,14 +155,19 @@ class RmaOrderLine(models.Model):
         "type",
         "qty_delivered",
         "qty_received",
+        "qty_outgoing",
     )
     def _compute_qty_to_deliver(self):
         for rec in self:
             rec.qty_to_deliver = 0.0
             if rec.delivery_policy == "ordered":
-                rec.qty_to_deliver = rec.product_qty - rec.qty_delivered
+                rec.qty_to_deliver = (
+                    rec.product_qty - rec.qty_delivered - rec.qty_outgoing
+                )
             elif rec.delivery_policy == "received":
-                rec.qty_to_deliver = rec.qty_received - rec.qty_delivered
+                rec.qty_to_deliver = (
+                    rec.qty_received - rec.qty_delivered - rec.qty_outgoing
+                )
 
     @api.depends("move_ids", "move_ids.state", "type")
     def _compute_qty_incoming(self):

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -559,7 +559,7 @@ class TestRma(common.TransactionCase):
         # product specific
         self._check_equal_quantity(
             lines.filtered(lambda l: l.product_id == self.product_1).qty_to_receive,
-            3,
+            0,
             "Wrong qty to receive",
         )
         self._check_equal_quantity(
@@ -569,7 +569,7 @@ class TestRma(common.TransactionCase):
         )
         self._check_equal_quantity(
             lines.filtered(lambda l: l.product_id == self.product_2).qty_to_receive,
-            5,
+            0,
             "Wrong qty to receive",
         )
         self._check_equal_quantity(
@@ -579,7 +579,7 @@ class TestRma(common.TransactionCase):
         )
         self._check_equal_quantity(
             lines.filtered(lambda l: l.product_id == self.product_3).qty_to_receive,
-            2,
+            0,
             "Wrong qty to receive",
         )
         self._check_equal_quantity(
@@ -678,7 +678,7 @@ class TestRma(common.TransactionCase):
         # product specific
         self._check_equal_quantity(
             lines.filtered(lambda l: l.product_id == self.product_1).qty_to_deliver,
-            3,
+            0,
             "Wrong qty to_deliver",
         )
         self._check_equal_quantity(
@@ -688,7 +688,7 @@ class TestRma(common.TransactionCase):
         )
         self._check_equal_quantity(
             lines.filtered(lambda l: l.product_id == self.product_2).qty_to_deliver,
-            5,
+            0,
             "Wrong qty to_deliver",
         )
         self._check_equal_quantity(
@@ -698,7 +698,7 @@ class TestRma(common.TransactionCase):
         )
         self._check_equal_quantity(
             lines.filtered(lambda l: l.product_id == self.product_3).qty_to_deliver,
-            2,
+            0,
             "Wrong qty to_deliver",
         )
         self._check_equal_quantity(
@@ -911,9 +911,9 @@ class TestRma(common.TransactionCase):
             "Wrong qty_to_receive",
         )
         self._check_equal_quantity(
-            lines.filtered(lambda l: l.product_id == self.product_1).qty_to_deliver,
+            lines.filtered(lambda l: l.product_id == self.product_1).qty_outgoing,
             3,
-            "Wrong qty_to_deliver",
+            "Wrong qty_outgoing",
         )
         self._check_equal_quantity(
             lines.filtered(lambda l: l.product_id == self.product_2).qty_to_receive,
@@ -921,9 +921,9 @@ class TestRma(common.TransactionCase):
             "Wrong qty_to_receive",
         )
         self._check_equal_quantity(
-            lines.filtered(lambda l: l.product_id == self.product_2).qty_to_deliver,
+            lines.filtered(lambda l: l.product_id == self.product_2).qty_outgoing,
             5,
-            "Wrong qty_to_deliver",
+            "Wrong qty_outgoing",
         )
         self._check_equal_quantity(
             lines.filtered(lambda l: l.product_id == self.product_3).qty_to_receive,
@@ -931,9 +931,9 @@ class TestRma(common.TransactionCase):
             "Wrong qty_to_receive",
         )
         self._check_equal_quantity(
-            lines.filtered(lambda l: l.product_id == self.product_3).qty_to_deliver,
+            lines.filtered(lambda l: l.product_id == self.product_3).qty_outgoing,
             2,
-            "Wrong qty_to_deliver",
+            "Wrong qty_outgoing",
         )
         self.assertEqual(
             list(set(lines.mapped("qty_incoming"))), [0], "Wrong qty_incoming"
@@ -1027,18 +1027,33 @@ class TestRma(common.TransactionCase):
         # product specific
         self._check_equal_quantity(
             lines.filtered(lambda l: l.product_id == self.product_1).qty_to_receive,
-            3,
+            0,
             "Wrong qty_to_receive",
+        )
+        self._check_equal_quantity(
+            lines.filtered(lambda l: l.product_id == self.product_1).qty_incoming,
+            3,
+            "Wrong qty_incoming",
         )
         self._check_equal_quantity(
             lines.filtered(lambda l: l.product_id == self.product_2).qty_to_receive,
-            5,
+            0,
             "Wrong qty_to_receive",
         )
         self._check_equal_quantity(
+            lines.filtered(lambda l: l.product_id == self.product_2).qty_incoming,
+            5,
+            "Wrong qty_incoming",
+        )
+        self._check_equal_quantity(
             lines.filtered(lambda l: l.product_id == self.product_3).qty_to_receive,
-            2,
+            0,
             "Wrong qty_to_receive",
+        )
+        self._check_equal_quantity(
+            lines.filtered(lambda l: l.product_id == self.product_3).qty_incoming,
+            2,
+            "Wrong qty_incoming",
         )
         picking_in.action_confirm()
         picking_in.action_assign()

--- a/rma_scrap/tests/test_rma_scrap.py
+++ b/rma_scrap/tests/test_rma_scrap.py
@@ -108,7 +108,7 @@ class TestRmaScrap(common.SingleTransactionCase):
 
         action_picking = wizard.action_create_picking()
         picking = self.env["stock.picking"].browse([action_picking["res_id"]])
-        picking.move_line_ids[0].qty_done = rma.qty_to_receive
+        picking.move_line_ids[0].qty_done = rma.qty_incoming
 
         picking.button_validate()
         rma._compute_qty_to_scrap()


### PR DESCRIPTION
This aims to fix an annoying bug.
Today, the create incoming shipment and delivery button are highlighted when the quantity to receive/to deliver is greater than 0.

The problem is, when you press the button and generate the incoming/outgoing shipment, the picking is generated and the button stay highlighted. This is because the incoming/outcoming quantity does not count when we recompute the to received / to deliver quantity.

It seems logical to me that the to receive / to deliver quantity is set to 0 when the related shipments are generated.
If it is actually wanted / normal to have both to receive and incoming quantity when the incoming shipment is created but not done yet, then I'll change the PR to add 2 computed fields to control the display of the create incoming/outgoing shipments. These computed fields would display the highlighted button if qty_to_receive > 0 AND qty_to_receive > incoming_qy
But my opinion is that it is confusing to have qty to receive and incoming_qty to 1 when you expect 1 product.
It seems like a redondant information.

What do you think @AaronHForgeFlow @DavidJForgeFlow 