### PR TITLE
[17.0][IMP] introduce fields in_force_same_lot and out_force_same_lot

### DIFF
--- a/rma/__manifest__.py
+++ b/rma/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "RMA (Return Merchandise Authorization)",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.1.0",
     "license": "LGPL-3",
     "category": "RMA",
     "summary": "Introduces the return merchandise authorization (RMA) process in odoo",

--- a/rma/data/rma_operation.xml
+++ b/rma/data/rma_operation.xml
@@ -8,6 +8,8 @@
         <field name="type">customer</field>
         <field name="in_route_id" ref="rma.route_rma_customer" />
         <field name="out_route_id" ref="rma.route_rma_customer" />
+        <field name="in_force_same_lot">True</field>
+        <field name="out_force_same_lot">False</field>
     </record>
 
     <record id="rma_operation_supplier_replace" model="rma.operation">
@@ -18,6 +20,8 @@
         <field name="type">supplier</field>
         <field name="in_route_id" ref="rma.route_rma_supplier" />
         <field name="out_route_id" ref="rma.route_rma_supplier" />
+        <field name="in_force_same_lot">False</field>
+        <field name="out_force_same_lot">True</field>
     </record>
 
     <record id="rma_operation_ds_replace" model="rma.operation">

--- a/rma/migrations/17.0.1.1.0/post-migration.py
+++ b/rma/migrations/17.0.1.1.0/post-migration.py
@@ -1,0 +1,28 @@
+# Copyright 2024 ForgeFlow S.L. (https://www.forgeflow.com)
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def _update_rma_operations(cr):
+    _logger.info(
+        "Updating rma operations to preset in_force_same_lot and out_force_same_lot"
+    )
+    cr.execute(
+        """
+        UPDATE rma_operation
+        SET in_force_same_lot=True
+        WHERE type='customer';
+    """
+    )
+    cr.execute(
+        """
+        UPDATE rma_operation
+        SET out_force_same_lot=True
+        WHERE type='supplier';
+    """
+    )
+
+
+def migrate(cr, version):
+    _update_rma_operations(cr)

--- a/rma/models/rma_operation.py
+++ b/rma/models/rma_operation.py
@@ -94,3 +94,22 @@ class RmaOperation(models.Model):
         required=True,
         default=lambda self: self.env.user.company_id,
     )
+    in_force_same_lot = fields.Boolean(
+        string="Force same lot in incoming shipments",
+        help="Forces the same lot to be used "
+        "in incoming pickings as the one indicated in the RMA",
+    )
+    out_force_same_lot = fields.Boolean(
+        string="Force same lot in outgoing shipments",
+        help="Forces the same lot to be used "
+        "in outgoing pickings as the one indicated in the RMA",
+    )
+
+    @api.onchange("type")
+    def _onchange_type(self):
+        if self.type == "customer":
+            self.in_force_same_lot = True
+            self.out_force_same_lot = False
+        elif self.type == "supplier":
+            self.in_force_same_lot = False
+            self.out_force_same_lot = True

--- a/rma/models/stock_move.py
+++ b/rma/models/stock_move.py
@@ -62,6 +62,7 @@ class StockMove(models.Model):
             not lot_id
             and self.rma_line_id.lot_id
             and self.location_id.usage == "internal"
+            and self.rma_line_id.operation_id.out_force_same_lot
         ):
             # In supplier RMA deliveries we can only send the RMA lot/serial.
             lot_id = self.rma_line_id.lot_id
@@ -88,6 +89,7 @@ class StockMove(models.Model):
             not lot_id
             and self.rma_line_id.lot_id
             and self.location_id.usage == "internal"
+            and self.rma_line_id.operation_id.out_force_same_lot
         ):
             # In supplier RMA deliveries we can only send the RMA lot/serial.
             lot_id = self.rma_line_id.lot_id

--- a/rma/views/rma_operation_view.xml
+++ b/rma/views/rma_operation_view.xml
@@ -53,6 +53,10 @@
                                 name="customer_to_supplier"
                                 invisible="type == 'supplier'"
                             />
+                            <field
+                                name="in_force_same_lot"
+                                groups="stock.group_production_lot"
+                            />
                         </group>
                         <group name="outbound" string="Outbound">
                             <field name="out_route_id" />
@@ -60,6 +64,10 @@
                             <field
                                 name="supplier_to_customer"
                                 invisible="type == 'customer'"
+                            />
+                            <field
+                                name="out_force_same_lot"
+                                groups="stock.group_production_lot"
                             />
                         </group>
                     </group>

--- a/rma/wizards/rma_make_picking.py
+++ b/rma/wizards/rma_make_picking.py
@@ -138,8 +138,11 @@ class RmaMakePicking(models.TransientModel):
             "location_id": location,
             "rma_line_id": line.id,
             "route_ids": route,
-            "restrict_lot_id": line.lot_id.id,
         }
+        if (picking_type == "incoming" and line.operation_id.in_force_same_lot) or (
+            picking_type == "outgoing" and line.operation_id.out_force_same_lot
+        ):
+            procurement_data["restrict_lot_id"] = line.lot_id.id
         return procurement_data
 
     @api.model


### PR DESCRIPTION
Those fields in the rma.operation allows us to control if we want to ensure that the same lot as the one indicated in the RMA should be used in deliveries to customers and receipts from suppliers

Based on #495 