### PR TITLE
[18][rma_account] Add possibility to create refund from rma group

### DIFF
--- a/rma_account/__manifest__.py
+++ b/rma_account/__manifest__.py
@@ -13,13 +13,13 @@
     "data": [
         "security/ir.model.access.csv",
         "data/rma_operation.xml",
+        "wizards/rma_add_account_move.xml",
+        "wizards/rma_refund.xml",
         "views/rma_order_view.xml",
         "views/rma_operation_view.xml",
         "views/rma_order_line_view.xml",
         "views/account_move_view.xml",
         "views/rma_account_menu.xml",
-        "wizards/rma_add_account_move.xml",
-        "wizards/rma_refund.xml",
     ],
     "installable": True,
 }

--- a/rma_account/i18n/fr.po
+++ b/rma_account/i18n/fr.po
@@ -1,0 +1,589 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* rma_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-16 14:25+0000\n"
+"PO-Revision-Date: 2024-09-16 14:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_order__invoice_count
+msgid "# of Invoices"
+msgstr "# de Factures"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_account_bank_statement_line__rma_count
+#: model:ir.model.fields,field_description:rma_account.field_account_move__rma_count
+#: model:ir.model.fields,field_description:rma_account.field_account_move_line__rma_line_count
+#: model:ir.model.fields,field_description:rma_account.field_account_payment__rma_count
+msgid "# of RMA"
+msgstr "# de RMA"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_order__invoice_refund_count
+#: model:ir.model.fields,field_description:rma_account.field_rma_order_line__refund_count
+msgid "# of Refunds"
+msgstr "# d'Avoirs"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_account_bank_statement_line__used_in_rma_count
+#: model:ir.model.fields,field_description:rma_account.field_account_move__used_in_rma_count
+#: model:ir.model.fields,field_description:rma_account.field_account_payment__used_in_rma_count
+msgid "# of Used in RMA"
+msgstr "# d'utilisés dans RMA"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_account_move_line__used_in_rma_line_count
+msgid "# of used RMA"
+msgstr "# de RMA utilisés"
+
+#. module: rma_account
+#: model:ir.ui.menu,name:rma_account.menu_rma_account
+msgid "Accounting"
+msgstr "Comptabilité"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund__date
+msgid "Accounting Date"
+msgstr "Date comptable"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_order__add_move_id
+msgid "Add Invoice"
+msgstr "Ajouter une facture"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_account_bank_statement_line__add_rma_line_id
+#: model:ir.model.fields,field_description:rma_account.field_account_move__add_rma_line_id
+#: model:ir.model.fields,field_description:rma_account.field_account_payment__add_rma_line_id
+msgid "Add from RMA line"
+msgstr "Ajouter depuis la ligne RMA"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_operation__automated_refund
+msgid "Automated Refund"
+msgstr "Remboursement automatisé"
+
+#. module: rma_account
+#: model:ir.model.fields.selection,name:rma_account.selection__rma_operation__refund_policy__delivered
+#: model:ir.model.fields.selection,name:rma_account.selection__rma_order_line__refund_policy__delivered
+msgid "Based on Delivered Quantities"
+msgstr "Basé sur les quantités livrées"
+
+#. module: rma_account
+#: model:ir.model.fields.selection,name:rma_account.selection__rma_operation__refund_policy__ordered
+#: model:ir.model.fields.selection,name:rma_account.selection__rma_order_line__refund_policy__ordered
+#: model:ir.model.fields.selection,name:rma_account.selection__rma_refund_item__refund_policy__ordered
+msgid "Based on Ordered Quantities"
+msgstr "Basé sur les quantités commandées"
+
+#. module: rma_account
+#: model:ir.model.fields.selection,name:rma_account.selection__rma_operation__refund_policy__received
+#: model:ir.model.fields.selection,name:rma_account.selection__rma_order_line__refund_policy__received
+#: model:ir.model.fields.selection,name:rma_account.selection__rma_refund_item__refund_policy__received
+msgid "Based on Received Quantities"
+msgstr "Basé sur les quantités reçues"
+
+#. module: rma_account
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_add_account_move
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_add_account_move_supplier
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_refund
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_order_line__commercial_partner_id
+msgid "Commercial Entity"
+msgstr "Entité commerciale"
+
+#. module: rma_account
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_add_account_move
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_add_account_move_supplier
+msgid "Confirm"
+msgstr "Confirmer"
+
+#. module: rma_account
+#: model:ir.actions.act_window,name:rma_account.action_rma_refund
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_form
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_line_form
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_refund
+msgid "Create Refund"
+msgstr "Créer un remboursement"
+
+#. module: rma_account
+#: model:ir.model.fields,help:rma_account.field_account_bank_statement_line__add_rma_line_id
+#: model:ir.model.fields,help:rma_account.field_account_move__add_rma_line_id
+#: model:ir.model.fields,help:rma_account.field_account_payment__add_rma_line_id
+msgid "Create a refund in based on an existing rma_line"
+msgstr "Créer un remboursement basé sur une ligne RMA existante"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_add_account_move__create_uid
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund__create_uid
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_add_account_move__create_date
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund__create_date
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: rma_account
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_refund
+msgid "Credit Note"
+msgstr "Note de crédit"
+
+#. module: rma_account
+#: model:ir.actions.act_window,name:rma_account.action_rma_account_customer_lines
+msgid "Customer RMA"
+msgstr "RMA Client"
+
+#. module: rma_account
+#: model:ir.ui.menu,name:rma_account.menu_rma_customer_refunds
+#: model:ir.ui.menu,name:rma_account.menu_rma_line_account_customer
+msgid "Customer RMA to Refund"
+msgstr "RMA client à rembourser"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__name
+msgid "Description"
+msgstr ""
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_add_account_move__display_name
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund__display_name
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__display_name
+msgid "Display Name"
+msgstr "Afficher un nom"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_add_account_move__id
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund__id
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__id
+msgid "ID"
+msgstr ""
+
+#. module: rma_account
+#: model:ir.model.fields,help:rma_account.field_rma_operation__refund_free_of_charge
+msgid ""
+"In case of automated refund you should mark this option as long "
+"automatedrefunds mean to compensate Stock Interim accounts only without "
+"hittingAccounts receivable"
+msgstr ""
+"En cas de remboursement automatique, vous devez cocher cette option car les "
+"remboursements automatisés longs visent à compenser uniquement les comptes "
+"Stock Provisoire sans affecter les comptes clients"
+
+#. module: rma_account
+#: model:ir.model.fields,help:rma_account.field_rma_operation__automated_refund
+msgid ""
+"In the scenario where a company uses anglo-saxon accounting, if you receive "
+"products from a customer and don't expect to refund the customer but send a "
+"replacement unit, mark this flag to be accounting consistent"
+msgstr ""
+"Dans le cas où une entreprise utilise la comptabilité anglo-saxonne, si vous"
+" recevez des produits d'un client et que vous n'espérez pas rembourser le "
+"client mais envoyer une unité de remplacement, cochez cette option pour être"
+" comptablement cohérent"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__invoice_address_id
+msgid "Invoice Address"
+msgstr "Addresse de facturation"
+
+#. module: rma_account
+#: model:ir.actions.act_window,name:rma_account.action_invoice_line
+msgid "Invoice Line"
+msgstr "Ligne de facture"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_add_account_move__line_ids
+msgid "Invoice Lines"
+msgstr "Lignes de facture"
+
+#. module: rma_account
+#: model:ir.model.fields,help:rma_account.field_rma_order_line__invoice_address_id
+msgid "Invoice address for current rma order."
+msgstr "Adresse de facturation pour la commande RMA en cours."
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund__item_ids
+msgid "Items"
+msgstr "Articles"
+
+#. module: rma_account
+#: model:ir.model,name:rma_account.model_account_move
+msgid "Journal Entry"
+msgstr "Pièce comptable"
+
+#. module: rma_account
+#: model:ir.model,name:rma_account.model_account_move_line
+msgid "Journal Item"
+msgstr "Écriture comptable"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_order_line__move_line_ids
+msgid "Journal Items"
+msgstr "Éléments du journal"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_add_account_move____last_update
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund____last_update
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_add_account_move__write_uid
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund__write_uid
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_add_account_move__write_date
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund__write_date
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: rma_account
+#: model:ir.model.fields.selection,name:rma_account.selection__rma_operation__refund_policy__no
+#: model:ir.model.fields.selection,name:rma_account.selection__rma_order_line__refund_policy__no
+msgid "No refund"
+msgstr "Aucun remboursement"
+
+#. module: rma_account
+#: model:ir.model.fields.selection,name:rma_account.selection__rma_refund_item__refund_policy__no
+msgid "Not required"
+msgstr "Non requis"
+
+#. module: rma_account
+#. odoo-python
+#: code:addons/rma_account/wizards/rma_refund.py:0
+#, python-format
+msgid "Only RMAs from the same partner can be processed at the same time."
+msgstr "Seuls les RMA provenant du même partenaire peuvent être traités en même temps."
+
+#. module: rma_account
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_form
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_line_form
+msgid "Origin Inv"
+msgstr "Facture Source"
+
+#. module: rma_account
+#. odoo-python
+#: code:addons/rma_account/models/rma_order.py:0
+#, python-format
+msgid "Originating Invoice"
+msgstr "Facture Source"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_order_line__account_move_line_id
+msgid "Originating Invoice Line"
+msgstr "Ligne de facture source"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_add_account_move__partner_id
+msgid "Partner"
+msgstr "Partenaire"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_order_line__invoice_address_id
+msgid "Partner invoice address"
+msgstr "Adresse de facturation du partenaire"
+
+#. module: rma_account
+#. odoo-python
+#: code:addons/rma_account/models/rma_order_line.py:0
+#: code:addons/rma_account/wizards/rma_add_account_move.py:0
+#, python-format
+msgid "Please define a warehouse with a default rma location"
+msgstr "Veuillez définir un entrepôt avec un emplacement rma par défaut"
+
+#. module: rma_account
+#. odoo-python
+#: code:addons/rma_account/models/rma_order_line.py:0
+#: code:addons/rma_account/wizards/rma_add_account_move.py:0
+#, python-format
+msgid "Please define an operation first"
+msgstr "Veuillez d'abord définir une opération"
+
+#. module: rma_account
+#. odoo-python
+#: code:addons/rma_account/models/rma_order_line.py:0
+#: code:addons/rma_account/wizards/rma_add_account_move.py:0
+#, python-format
+msgid "Please define an rma route"
+msgstr "Veuillez définir une route rma"
+
+#. module: rma_account
+#: model:ir.model,name:rma_account.model_procurement_group
+msgid "Procurement Group"
+msgstr "Groupe d'approvisionnement"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__product
+msgid "Product"
+msgstr "Produit"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__product_id
+msgid "Product (Technical)"
+msgstr "Produit (Technique)"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_order_line__qty_refunded
+msgid "Qty Refunded"
+msgstr "Qté remboursée"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_order__qty_to_refund
+#: model:ir.model.fields,field_description:rma_account.field_rma_order_line__qty_to_refund
+msgid "Qty To Refund"
+msgstr "Qté à rembourser"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__product_qty
+msgid "Quantity Ordered"
+msgstr "Quantité commandée"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__qty_to_refund
+msgid "Quantity To Refund"
+msgstr "Quantité à rembourser"
+
+#. module: rma_account
+#: model:ir.model,name:rma_account.model_rma_order_line
+#: model:ir.model.fields,field_description:rma_account.field_account_move_line__rma_line_ids
+#: model:ir.model.fields,field_description:rma_account.field_procurement_group__rma_id
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__rma_id
+#: model_terms:ir.ui.view,arch_db:rma_account.invoice_form
+msgid "RMA"
+msgstr ""
+
+#. module: rma_account
+#. odoo-python
+#: code:addons/rma_account/wizards/rma_refund.py:0
+#, python-format
+msgid "RMA %s is not approved"
+msgstr "RMA %s n'est pas approuvé"
+
+#. module: rma_account
+#: model:ir.model,name:rma_account.model_rma_order
+msgid "RMA Group"
+msgstr "Groupe RMA"
+
+#. module: rma_account
+#: model_terms:ir.ui.view,arch_db:rma_account.view_invoice_line_form
+msgid "RMA Lines"
+msgstr "Lignes RMA"
+
+#. module: rma_account
+#: model:ir.model,name:rma_account.model_rma_refund_item
+msgid "RMA Lines to refund"
+msgstr "Lignes RMA à rembourser"
+
+#. module: rma_account
+#: model:ir.model,name:rma_account.model_rma_operation
+msgid "RMA Operation"
+msgstr "Opération RMA"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_add_account_move__rma_id
+msgid "RMA Order"
+msgstr "Commande RMA"
+
+#. module: rma_account
+#. odoo-python
+#: code:addons/rma_account/models/rma_order_line.py:0
+#, python-format
+msgid "RMA customer and originating invoice line customer doesn't match."
+msgstr "Le client RMA et le client sur la ligne de facture source ne correspondent pas."
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_account_move_line__rma_line_id
+#: model:ir.model.fields,field_description:rma_account.field_procurement_group__rma_line_id
+msgid "RMA line"
+msgstr "Ligne RMA"
+
+#. module: rma_account
+#: model_terms:ir.ui.view,arch_db:rma_account.view_invoice_line_form
+msgid "RMA line originated"
+msgstr "Origine de la ligne RMA"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__line_id
+msgid "RMA order Line"
+msgstr "Ligne de commande RMA"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund__description
+msgid "Reason"
+msgstr "Raison"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_operation__refund_journal_id
+msgid "Refund Account Journal"
+msgstr "Journal du compte d'avoir"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund__date_invoice
+msgid "Refund Date"
+msgstr "Date de remboursement"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_operation__refund_free_of_charge
+msgid "Refund Free Of Charge"
+msgstr "Remboursement sans frais"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_order_line__refund_line_ids
+msgid "Refund Lines"
+msgstr "Lignes d'avoir"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_operation__refund_policy
+#: model:ir.model.fields,field_description:rma_account.field_rma_order_line__refund_policy
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__refund_policy
+msgid "Refund Policy"
+msgstr "Politique de remboursement"
+
+#. module: rma_account
+#. odoo-python
+#: code:addons/rma_account/wizards/rma_refund.py:0
+#, python-format
+msgid "Refund created by %(rnr)s, %(r)s"
+msgstr "Avoir créé par %(rnr)s, %(r)s"
+
+#. module: rma_account
+#. odoo-python
+#: code:addons/rma_account/wizards/rma_refund.py:0
+#, python-format
+msgid "Refund created by %s"
+msgstr "Avoir créé par %s"
+
+#. module: rma_account
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_form
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_line_form
+msgid "Refunds"
+msgstr "Avoirs"
+
+#. module: rma_account
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_add_account_move
+msgid "Select Invoice from customer"
+msgstr "Sélectionnez la Facture client"
+
+#. module: rma_account
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_add_account_move_supplier
+msgid "Select Invoice from supplier"
+msgstr "Sélectionnez la Facture fournisseur"
+
+#. module: rma_account
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_add_account_move
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_add_account_move_supplier
+msgid "Select Invoices lines to add"
+msgstr "Sélectionnez les lignes de facture à ajouter"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_order_line__move_id
+msgid "Source"
+msgstr ""
+
+#. module: rma_account
+#: model:ir.model,name:rma_account.model_stock_move
+msgid "Stock Move"
+msgstr "Mouvement de stock"
+
+#. module: rma_account
+#: model:ir.model,name:rma_account.model_stock_valuation_layer
+msgid "Stock Valuation Layer"
+msgstr "Couche de valorisation d'inventaire"
+
+#. module: rma_account
+#: model:ir.actions.act_window,name:rma_account.action_rma_supplier_lines
+msgid "Supplier RMA"
+msgstr "RMA Fournisseur"
+
+#. module: rma_account
+#: model:ir.ui.menu,name:rma_account.menu_rma_line_account_supplier
+#: model:ir.ui.menu,name:rma_account.menu_rma_line_supplier_refunds
+msgid "Supplier RMA to Refund"
+msgstr "RMA Fournisseur à rembourser"
+
+#. module: rma_account
+#. odoo-python
+#: code:addons/rma_account/wizards/rma_refund.py:0
+#, python-format
+msgid "The invoice address must be the same for all the lines."
+msgstr "L'adresse de facturation doit être la même pour toutes les lignes."
+
+#. module: rma_account
+#. odoo-python
+#: code:addons/rma_account/models/rma_order_line.py:0
+#, python-format
+msgid "There's an rma for the invoice line %(arg1)s and invoice %(arg2)s"
+msgstr "Il existe un rma pour la ligne de facture %(arg1)s et la facture %(arg2)s"
+
+#. module: rma_account
+#: model:ir.model.fields,help:rma_account.field_account_move_line__rma_line_ids
+msgid "This will contain the RMA lines for the invoice line"
+msgstr "Celui-ci contiendra les lignes RMA pour la ligne de facture"
+
+#. module: rma_account
+#: model:ir.model.fields,help:rma_account.field_account_move_line__rma_line_id
+msgid "This will contain the rma line that originated this line"
+msgstr "Celui-ci contiendra la ligne rma à l'origine de cette ligne"
+
+#. module: rma_account
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_rma_line_filter
+msgid "To Refund"
+msgstr "A rembourser"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__uom_id
+msgid "Unit of Measure"
+msgstr "Unité de mesure"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_operation__valid_refund_journal_ids
+msgid "Valid Refund Journal"
+msgstr "Journal de remboursement valide"
+
+#. module: rma_account
+#: model:ir.model.fields,field_description:rma_account.field_rma_refund_item__wiz_id
+msgid "Wizard"
+msgstr "Assistant"
+
+#. module: rma_account
+#: model:ir.model,name:rma_account.model_rma_refund
+msgid "Wizard for RMA Refund"
+msgstr "Assistant de remboursement RMA"
+
+#. module: rma_account
+#: model:ir.model,name:rma_account.model_rma_add_account_move
+msgid "Wizard to add rma lines"
+msgstr "Assistant pour ajouter des lignes RMA"
+
+#. module: rma_account
+#: model:ir.model,name:rma_account.model_rma_make_supplier_rma
+msgid "Wizard to create Supplier RMA from rma"
+msgstr "Assistant pour créer un RMA fournisseur à partir d'un RMA"
+
+#. module: rma_account
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_add_account_move
+#: model_terms:ir.ui.view,arch_db:rma_account.view_rma_add_account_move_supplier
+msgid "or"
+msgstr "ou"

--- a/rma_account/models/rma_order.py
+++ b/rma_account/models/rma_order.py
@@ -17,6 +17,11 @@ class RmaOrder(models.Model):
             invoices = rec.mapped("rma_line_ids.move_id")
             rec.invoice_count = len(invoices)
 
+    @api.depends("rma_line_ids", "rma_line_ids.qty_to_refund")
+    def _compute_qty_to_refund(self):
+        for rec in self:
+            rec.qty_to_refund = sum(rec.rma_line_ids.mapped("qty_to_refund"))
+
     add_move_id = fields.Many2one(
         comodel_name="account.move",
         string="Add Invoice",
@@ -28,6 +33,10 @@ class RmaOrder(models.Model):
     )
     invoice_count = fields.Integer(
         compute="_compute_invoice_count", string="# of Invoices"
+    )
+    qty_to_refund = fields.Float(
+        digits="Product Unit of Measure",
+        compute="_compute_qty_to_refund",
     )
 
     def _prepare_rma_line_from_inv_line(self, line):

--- a/rma_account/models/rma_order.py
+++ b/rma_account/models/rma_order.py
@@ -1,7 +1,7 @@
 # Copyright 2017-22 ForgeFlow S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class RmaOrder(models.Model):
@@ -104,25 +104,22 @@ class RmaOrder(models.Model):
         return res
 
     def action_view_invoice_refund(self):
-        move_ids = self.mapped("rma_line_ids.move_id").ids
+        move_ids = self.mapped("rma_line_ids.refund_line_ids.move_id").ids
         form_view_ref = self.env.ref("account.view_move_form", False)
         list_view_ref = self.env.ref("account.view_move_tree", False)
-
-        return {
-            "domain": [("id", "in", move_ids)],
-            "name": "Refunds",
-            "res_model": "account.move",
-            "views": [(list_view_ref.id, "list"), (form_view_ref.id, "form")],
-        }
+        action = self.env.ref("account.action_move_in_refund_type")
+        result = action.sudo().read()[0]
+        result["domain"] = [("id", "in", move_ids)]
+        result["views"] = [(list_view_ref.id, "list"), (form_view_ref.id, "form")]
+        return result
 
     def action_view_invoice(self):
         move_ids = self.mapped("rma_line_ids.move_id").ids
         form_view_ref = self.env.ref("account.view_move_form", False)
         list_view_ref = self.env.ref("account.view_move_tree", False)
-
-        return {
-            "domain": [("id", "in", move_ids)],
-            "name": "Originating Invoice",
-            "res_model": "account.move",
-            "views": [(list_view_ref.id, "list"), (form_view_ref.id, "form")],
-        }
+        action = self.env.ref("account.action_move_out_invoice_type")
+        result = action.sudo().read()[0]
+        result["domain"] = [("id", "in", move_ids)]
+        result["views"] = [(list_view_ref.id, "list"), (form_view_ref.id, "form")]
+        result["name"] = _("Originating Invoice")
+        return result

--- a/rma_account/views/rma_order_line_view.xml
+++ b/rma_account/views/rma_order_line_view.xml
@@ -24,6 +24,21 @@
         <field name="model">rma.order.line</field>
         <field name="inherit_id" ref="rma.view_rma_line_form" />
         <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button
+                    name="%(rma_account.action_rma_refund)d"
+                    string="Create Refund"
+                    class="oe_highlight"
+                    invisible="qty_to_refund == 0 or qty_to_refund &lt; 0 or state != 'approved' or refund_policy == 'no'"
+                    type="action"
+                />
+                <button
+                    name="%(rma_account.action_rma_refund)d"
+                    string="Create Refund"
+                    invisible="qty_to_refund > 0 or state != 'approved' or refund_policy == 'no'"
+                    type="action"
+                />
+            </xpath>
             <button name="action_view_out_shipments" position="after">
                 <button
                     type="object"

--- a/rma_account/views/rma_order_view.xml
+++ b/rma_account/views/rma_order_view.xml
@@ -32,6 +32,9 @@
             <xpath expr="//field[@name='rma_line_ids']/list" position="inside">
                 <field name="refund_policy" invisible="True" />
             </xpath>
+            <xpath expr="//field[@name='qty_to_deliver']" position="after">
+                <field name="qty_to_refund" invisible="1" />
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/rma_account/views/rma_order_view.xml
+++ b/rma_account/views/rma_order_view.xml
@@ -5,6 +5,21 @@
         <field name="model">rma.order</field>
         <field name="inherit_id" ref="rma.view_rma_form" />
         <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button
+                    name="%(rma_account.action_rma_refund)d"
+                    string="Create Refund"
+                    class="oe_highlight"
+                    invisible="qty_to_refund == 0 or qty_to_refund &lt; 0 or state != 'approved'"
+                    type="action"
+                />
+                <button
+                    name="%(rma_account.action_rma_refund)d"
+                    string="Create Refund"
+                    invisible="qty_to_refund > 0 or state != 'approved'"
+                    type="action"
+                />
+            </xpath>
             <button name="action_view_out_shipments" position="after">
                 <button
                     type="object"

--- a/rma_account/views/rma_order_view.xml
+++ b/rma_account/views/rma_order_view.xml
@@ -23,7 +23,7 @@
                     name="action_view_invoice_refund"
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
-                    attrs="{'invisible': [('invoice_refund_count', '=', 0)]}"
+                    invisible="invoice_refund_count == 0"
                     groups="account.group_account_invoice"
                 >
                     <field
@@ -37,7 +37,7 @@
                     name="action_view_invoice"
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
-                    attrs="{'invisible': [('invoice_count', '=', 0)]}"
+                    invisible="invoice_count == 0"
                     groups="account.group_account_invoice"
                 >
                     <field name="invoice_count" widget="statinfo" string="Origin Inv" />

--- a/rma_account/views/rma_order_view.xml
+++ b/rma_account/views/rma_order_view.xml
@@ -5,18 +5,15 @@
         <field name="model">rma.order</field>
         <field name="inherit_id" ref="rma.view_rma_form" />
         <field name="arch" type="xml">
-            <xpath expr="//header" position="inside">
+            <xpath
+                expr="//header/button[@name='%(rma.action_make_supplier_rma)d']"
+                position="after"
+            >
                 <button
                     name="%(rma_account.action_rma_refund)d"
                     string="Create Refund"
                     class="oe_highlight"
                     invisible="qty_to_refund == 0 or qty_to_refund &lt; 0 or state != 'approved'"
-                    type="action"
-                />
-                <button
-                    name="%(rma_account.action_rma_refund)d"
-                    string="Create Refund"
-                    invisible="qty_to_refund > 0 or state != 'approved'"
                     type="action"
                 />
             </xpath>
@@ -26,6 +23,7 @@
                     name="action_view_invoice_refund"
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
+                    attrs="{'invisible': [('invoice_refund_count', '=', 0)]}"
                     groups="account.group_account_invoice"
                 >
                     <field
@@ -39,6 +37,7 @@
                     name="action_view_invoice"
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
+                    attrs="{'invisible': [('invoice_count', '=', 0)]}"
                     groups="account.group_account_invoice"
                 >
                     <field name="invoice_count" widget="statinfo" string="Origin Inv" />

--- a/rma_account/wizards/__init__.py
+++ b/rma_account/wizards/__init__.py
@@ -3,4 +3,4 @@
 
 from . import rma_refund
 from . import rma_add_account_move
-from . import rma_order_line_make_supplier_rma
+from . import rma_make_supplier_rma

--- a/rma_account/wizards/rma_make_supplier_rma.py
+++ b/rma_account/wizards/rma_make_supplier_rma.py
@@ -4,8 +4,8 @@
 from odoo import api, models
 
 
-class RmaLineMakeSupplierRma(models.TransientModel):
-    _inherit = "rma.order.line.make.supplier.rma"
+class RmaMakeSupplierRma(models.TransientModel):
+    _inherit = "rma.make.supplier.rma"
 
     @api.model
     def _prepare_supplier_rma_line(self, rma, item):

--- a/rma_account/wizards/rma_refund.py
+++ b/rma_account/wizards/rma_refund.py
@@ -12,7 +12,14 @@ class RmaRefund(models.TransientModel):
     @api.model
     def _get_reason(self):
         active_ids = self.env.context.get("active_ids", False)
-        return self.env["rma.order.line"].browse(active_ids[0]).rma_id.name or ""
+        active_model = self.env.context.get("active_model", False)
+        reason = ""
+        if active_model and active_ids:
+            if active_model == "rma.order":
+                reason = self.env[active_model].browse(active_ids[0]).name or ""
+            else:
+                reason = self.env[active_model].browse(active_ids[0]).rma_id.name or ""
+        return reason
 
     @api.returns("rma.order.line")
     def _prepare_item(self, line):
@@ -39,14 +46,22 @@ class RmaRefund(models.TransientModel):
         context = self._context.copy()
         res = super().default_get(fields_list)
         rma_line_obj = self.env["rma.order.line"]
-        rma_line_ids = self.env.context["active_ids"] or []
-        active_model = self.env.context["active_model"]
-        if not rma_line_ids:
+        rma_obj = self.env["rma.order"]
+        active_ids = context.get("active_ids") or []
+        active_model = context.get("active_model")
+        if not active_ids:
             return res
-        assert active_model == "rma.order.line", "Bad context propagation"
+        assert active_model in [
+            "rma.order.line",
+            "rma.order",
+        ], "Bad context propagation"
 
         items = []
-        lines = rma_line_obj.browse(rma_line_ids)
+        if active_model == "rma.order":
+            rma = rma_obj.browse(active_ids)
+            lines = rma.rma_line_ids
+        else:
+            lines = rma_line_obj.browse(active_ids)
         if len(lines.mapped("partner_id")) > 1:
             raise ValidationError(
                 _(
@@ -90,8 +105,16 @@ class RmaRefund(models.TransientModel):
             return new_refund
 
     def invoice_refund(self):
-        rma_line_ids = self.env["rma.order.line"].browse(self.env.context["active_ids"])
-        for line in rma_line_ids:
+        rma_line_obj = self.env["rma.order.line"]
+        rma_obj = self.env["rma.order"]
+        active_ids = self.env.context.get("active_ids") or []
+        active_model = self.env.context.get("active_model")
+        if active_model == "rma.order":
+            rma = rma_obj.browse(active_ids)
+            lines = rma.rma_line_ids
+        else:
+            lines = rma_line_obj.browse(active_ids)
+        for line in lines:
             if line.state != "approved":
                 raise ValidationError(_("RMA %s is not approved") % line.name)
         new_invoice = self.compute_refund()

--- a/rma_account/wizards/rma_refund.py
+++ b/rma_account/wizards/rma_refund.py
@@ -59,7 +59,7 @@ class RmaRefund(models.TransientModel):
         items = []
         if active_model == "rma.order":
             rma = rma_obj.browse(active_ids)
-            lines = rma.rma_line_ids
+            lines = rma.rma_line_ids.filtered(lambda x: x.qty_to_refund > 0)
         else:
             lines = rma_line_obj.browse(active_ids)
         if len(lines.mapped("partner_id")) > 1:
@@ -105,15 +105,7 @@ class RmaRefund(models.TransientModel):
             return new_refund
 
     def invoice_refund(self):
-        rma_line_obj = self.env["rma.order.line"]
-        rma_obj = self.env["rma.order"]
-        active_ids = self.env.context.get("active_ids") or []
-        active_model = self.env.context.get("active_model")
-        if active_model == "rma.order":
-            rma = rma_obj.browse(active_ids)
-            lines = rma.rma_line_ids
-        else:
-            lines = rma_line_obj.browse(active_ids)
+        lines = self.item_ids.line_id
         for line in lines:
             if line.state != "approved":
                 raise ValidationError(_("RMA %s is not approved") % line.name)

--- a/rma_account/wizards/rma_refund.xml
+++ b/rma_account/wizards/rma_refund.xml
@@ -71,4 +71,26 @@
             </xpath>
         </field>
     </record>
+
+    <record id="view_rma_button_refund_form" model="ir.ui.view">
+        <field name="model">rma.order</field>
+        <field name="inherit_id" ref="rma.view_rma_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button
+                    name="%(action_rma_refund)d"
+                    string="Create Refund"
+                    class="oe_highlight"
+                    attrs="{'invisible':['|', '|', ('qty_to_refund', '=', 0),  ('qty_to_refund', '&lt;', 0), ('state', '!=', 'approved')]}"
+                    type="action"
+                />
+                <button
+                    name="%(action_rma_refund)d"
+                    string="Create Refund"
+                    attrs="{'invisible':['|', ('qty_to_refund', '>', 0), ('state', '!=', 'approved')]}"
+                    type="action"
+                />
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/rma_account/wizards/rma_refund.xml
+++ b/rma_account/wizards/rma_refund.xml
@@ -48,49 +48,4 @@
         <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]" />
         <field name="target">new</field>
     </record>
-
-    <record id="view_rma_line_button_refund_form" model="ir.ui.view">
-        <field name="name">rma.order.line.form</field>
-        <field name="model">rma.order.line</field>
-        <field name="inherit_id" ref="rma.view_rma_line_form" />
-        <field name="arch" type="xml">
-            <xpath expr="//header" position="inside">
-                <button
-                    name="%(action_rma_refund)d"
-                    string="Create Refund"
-                    class="oe_highlight"
-                    invisible="qty_to_refund == 0 or qty_to_refund &lt; 0 or state != 'approved' or refund_policy == 'no'"
-                    type="action"
-                />
-                <button
-                    name="%(action_rma_refund)d"
-                    string="Create Refund"
-                    invisible="qty_to_refund > 0 or state != 'approved' or refund_policy == 'no'"
-                    type="action"
-                />
-            </xpath>
-        </field>
-    </record>
-
-    <record id="view_rma_button_refund_form" model="ir.ui.view">
-        <field name="model">rma.order</field>
-        <field name="inherit_id" ref="rma.view_rma_form" />
-        <field name="arch" type="xml">
-            <xpath expr="//header" position="inside">
-                <button
-                    name="%(action_rma_refund)d"
-                    string="Create Refund"
-                    class="oe_highlight"
-                    attrs="{'invisible':['|', '|', ('qty_to_refund', '=', 0),  ('qty_to_refund', '&lt;', 0), ('state', '!=', 'approved')]}"
-                    type="action"
-                />
-                <button
-                    name="%(action_rma_refund)d"
-                    string="Create Refund"
-                    attrs="{'invisible':['|', ('qty_to_refund', '>', 0), ('state', '!=', 'approved')]}"
-                    type="action"
-                />
-            </xpath>
-        </field>
-    </record>
 </odoo>


### PR DESCRIPTION
This is a port of https://github.com/ForgeFlow/stock-rma/pull/508 (which is approved already)
But splitted in 3 PR, one per module (rma, rma_account, rma_sale)
The goal is to merge it in this recent version since it may seems a lot of change for a stable version (but it is actually very few changes, things is some refactore in views was also done (move rma.order and rma.order.line view override from wizard to view folder).

This PR on rma add 1 button on RMA group :
- Refund creation

@AaronHForgeFlow @sebastienbeau @JasminSForgeFlow