### PR TITLE
[18][rma_sale] Add possibility to create sale order from rma group

### DIFF
--- a/rma_sale/__manifest__.py
+++ b/rma_sale/__manifest__.py
@@ -13,11 +13,11 @@
     "data": [
         "security/ir.model.access.csv",
         "data/rma_operation.xml",
+        "wizards/rma_make_sale_order_view.xml",
+        "wizards/rma_add_sale.xml",
         "views/rma_order_view.xml",
         "views/rma_operation_view.xml",
         "views/sale_order_view.xml",
-        "wizards/rma_order_line_make_sale_order_view.xml",
-        "wizards/rma_add_sale.xml",
         "views/rma_order_line_view.xml",
     ],
     "installable": True,

--- a/rma_sale/i18n/fr.po
+++ b/rma_sale/i18n/fr.po
@@ -1,0 +1,502 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* rma_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-16 14:27+0000\n"
+"PO-Revision-Date: 2024-09-16 14:27+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order__src_sale_count
+msgid "# of Origin Sales"
+msgstr "# de Ventes Sources"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_sale_order__rma_count
+msgid "# of RMA"
+msgstr "# de RMA"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order__sale_count
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line__sales_count
+msgid "# of Sales"
+msgstr "# de Commandes de Ventes"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_form
+msgid "Add From Sale Order"
+msgstr "Ajouter à partir des Ventes"
+
+#. module: rma_sale
+#. odoo-python
+#: code:addons/rma_sale/wizards/rma_add_sale.py:0
+#: model:ir.actions.act_window,name:rma_sale.action_rma_add_sale
+#, python-format
+msgid "Add Sale Order"
+msgstr "Ajouter Commande de Vente"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_operation__auto_confirm_rma_sale
+msgid "Auto confirm Sales Order upon creation from RMA"
+msgstr "Confirmer automatiquement la commande client lors de sa création à partir du RMA"
+
+#. module: rma_sale
+#: model:ir.model.fields.selection,name:rma_sale.selection__rma_operation__sale_policy__ordered
+#: model:ir.model.fields.selection,name:rma_sale.selection__rma_order_line__sale_policy__ordered
+msgid "Based on Ordered Quantities"
+msgstr "Basé sur les Quantités Commandées"
+
+#. module: rma_sale
+#: model:ir.model.fields.selection,name:rma_sale.selection__rma_operation__sale_policy__received
+#: model:ir.model.fields.selection,name:rma_sale.selection__rma_order_line__sale_policy__received
+msgid "Based on Received Quantities"
+msgstr "Basé sur les Qauntités Reçues"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_add_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_order_line_make_sale_order
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_add_sale
+msgid "Confirm"
+msgstr "Confirmer"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_order_line_make_sale_order
+msgid "Create Quotation"
+msgstr "Créer Devis"
+
+#. module: rma_sale
+#: model:ir.actions.act_window,name:rma_sale.action_rma_make_sale_order
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_form
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_line_form
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_order_line_make_sale_order
+msgid "Create Sales Quotation"
+msgstr "Créer Commandes/Devis"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__create_uid
+#: model:ir.model.fields,field_description:rma_sale.field_rma_make_sale_order__create_uid
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__create_date
+#: model:ir.model.fields,field_description:rma_sale.field_rma_make_sale_order__create_date
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_make_sale_order__partner_id
+msgid "Customer"
+msgstr "Client"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__name
+msgid "Description"
+msgstr ""
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__display_name
+#: model:ir.model.fields,field_description:rma_sale.field_rma_make_sale_order__display_name
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: rma_sale
+#. odoo-python
+#: code:addons/rma_sale/wizards/rma_make_sale_order.py:0
+#, python-format
+msgid "Enter a customer."
+msgstr "Entrer un client"
+
+#. module: rma_sale
+#. odoo-python
+#: code:addons/rma_sale/wizards/rma_make_sale_order.py:0
+#, python-format
+msgid "Enter a positive quantity."
+msgstr "Entrer une quantité"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_order_line_make_sale_order
+msgid "Existing Quotation to update:"
+msgstr "devis existant à mettre à jour:"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__free_of_charge
+msgid "Free of Charge"
+msgstr "Gratuit"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_operation__free_of_charge_rma_sale
+msgid "Free of charge RMA Sales Order"
+msgstr "Commande RMA gratuite"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__id
+#: model:ir.model.fields,field_description:rma_sale.field_rma_make_sale_order__id
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__id
+msgid "ID"
+msgstr ""
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_make_sale_order__item_ids
+msgid "Items"
+msgstr "Articles"
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_rma_make_picking_wizard_item
+msgid "Items to receive"
+msgstr "Articles à recevoir"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale____last_update
+#: model:ir.model.fields,field_description:rma_sale.field_rma_make_sale_order____last_update
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__write_uid
+#: model:ir.model.fields,field_description:rma_sale.field_rma_make_sale_order__write_uid
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__write_date
+#: model:ir.model.fields,field_description:rma_sale.field_rma_make_sale_order__write_date
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__lot_domain_ids
+msgid "Lots Domain"
+msgstr ""
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__lot_ids
+msgid "Lots/Serials selected"
+msgstr "Lots/Séries sélectionnés"
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_rma_make_sale_order
+msgid "Make Sales Order from RMA"
+msgstr "Créer commande client à partir de RMA"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_order_line_make_sale_order
+msgid "New Sales Order details:"
+msgstr "Détails de la nouvelle commande client:"
+
+#. module: rma_sale
+#: model:ir.model.fields.selection,name:rma_sale.selection__rma_operation__sale_policy__no
+#: model:ir.model.fields.selection,name:rma_sale.selection__rma_order_line__sale_policy__no
+msgid "Not required"
+msgstr "Non requis"
+
+#. module: rma_sale
+#. odoo-python
+#: code:addons/rma_sale/wizards/rma_make_sale_order.py:0
+#, python-format
+msgid "Only RMA lines from the same partner can be processed at the same time"
+msgstr "Seules les lignes RMA du même partenaire peuvent être traitées en même temps"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__sale_id
+msgid "Order"
+msgstr "Commande"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_form
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_line_form
+msgid "Origin Sale Order"
+msgstr "Commandes de Vente Sources"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line__sale_line_id
+msgid "Originating Sales Order Line"
+msgstr "Ligne de commande d'origine"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__out_warehouse_id
+msgid "Outbound Warehouse"
+msgstr "Entrepôt sortant"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__partner_id
+msgid "Partner"
+msgstr "Partenaire"
+
+#. module: rma_sale
+#. odoo-python
+#: code:addons/rma_sale/models/rma_order_line.py:0
+#, python-format
+msgid "Please define a warehouse with a default RMA location."
+msgstr "Veuillez définir un entrepôt avec un emplacement RMA par défaut."
+
+#. module: rma_sale
+#. odoo-python
+#: code:addons/rma_sale/wizards/rma_add_sale.py:0
+#, python-format
+msgid "Please define a warehouse with a default rma location."
+msgstr "Veuillez définir un entrepôt avec un emplacement rma par défaut."
+
+#. module: rma_sale
+#. odoo-python
+#: code:addons/rma_sale/models/rma_order_line.py:0
+#, python-format
+msgid "Please define an RMA route"
+msgstr "Veuillez définir une route RMA"
+
+#. module: rma_sale
+#. odoo-python
+#: code:addons/rma_sale/models/rma_order_line.py:0
+#: code:addons/rma_sale/wizards/rma_add_sale.py:0
+#, python-format
+msgid "Please define an operation first"
+msgstr "Veuillez d'abord définir une opération"
+
+#. module: rma_sale
+#. odoo-python
+#: code:addons/rma_sale/wizards/rma_add_sale.py:0
+#, python-format
+msgid "Please define an rma route"
+msgstr "Veuillez définir une route RMA"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__product_id
+msgid "Product"
+msgstr "Produit"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_add_sale
+msgid "Qty"
+msgstr "Qté"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line__qty_sold
+msgid "Qty Sold"
+msgstr "Qté Vendue"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order__qty_to_sell
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line__qty_to_sell
+msgid "Qty To Sell"
+msgstr "Qté à Vendre"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__product_qty
+msgid "Quantity to sell"
+msgstr "Quantité à vendre"
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_rma_order_line
+#: model:ir.model.fields,field_description:rma_sale.field_sale_order_line__rma_line_id
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_order_form_inherit_sale_rma
+msgid "RMA"
+msgstr ""
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_rma_order
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__rma_id
+msgid "RMA Group"
+msgstr "Groupe RMA"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__line_id
+msgid "RMA Line"
+msgstr "Ligne RMA"
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_rma_order_line_make_sale_order_item
+msgid "RMA Line Make Sale Order Item"
+msgstr "Ligne RMA Crée une ligne de commande de vente"
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_rma_refund_item
+msgid "RMA Lines to refund"
+msgstr "Lignes RMA à rembourser"
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_rma_operation
+msgid "RMA Operation"
+msgstr "Opération RMA"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__rma_id
+msgid "RMA Order"
+msgstr "Commande RMA"
+
+#. module: rma_sale
+#. odoo-python
+#: code:addons/rma_sale/models/rma_order_line.py:0
+#, python-format
+msgid "RMA customer and originating sales order line customer doesn't match."
+msgstr "Le client RMA et le client sur la ligne de commande d'origine ne correspondent pas"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_sale_order__rma_line_ids
+msgid "Rma Line"
+msgstr "Ligne RMA"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_make_picking_wizard_item__sale_line_id
+msgid "Sale Line"
+msgstr "Ligne de vente"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__sale_line_ids
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_line_form
+msgid "Sale Lines"
+msgstr "Lignes de vente"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_refund_item__sale_line_id
+msgid "Sale Order Line"
+msgstr ""
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_add_sale
+msgid "Sale Order Lines"
+msgstr "Lignes de commande de vente"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_operation__sale_policy
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line__sale_policy
+msgid "Sale Policy"
+msgstr "Politique de vente"
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_sale_order
+#: model:ir.model.fields,field_description:rma_sale.field_rma_make_sale_order__sale_order_id
+msgid "Sales Order"
+msgstr "Bon de commande"
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Ligne de commande"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line__sale_line_ids
+msgid "Sales Order Lines"
+msgstr "Lignes de commande de vente"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_form
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_line_form
+msgid "Sales Orders"
+msgstr "Bons de commande"
+
+#. module: rma_sale
+#: model:ir.model.fields,help:rma_sale.field_rma_operation__free_of_charge_rma_sale
+msgid "Sales orders created from RMA are free of charge by default"
+msgstr "Les commandes client créées à partir de RMA sont gratuites par défaut"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_add_sale
+msgid "Select Sale Order Lines to Add"
+msgstr "Sélectionner les lignes de commande à ajouter"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_add_sale
+msgid "Select Sale Order from customer"
+msgstr "Sélectionner la commande de vente du client"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_add_sale
+msgid "Select all"
+msgstr "Sélectionner tout"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_add_sale
+msgid "Selected Lot/Serial Numbers"
+msgstr "Numéros de lot/série sélectionnés"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_add_sale__show_lot_filter
+msgid "Show lot filter?"
+msgstr "Afficher le filtre de lot ?"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line__sale_id
+msgid "Source Sales Order"
+msgstr "Bons de commande Sources"
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_stock_rule
+msgid "Stock Rule"
+msgstr "Règle de stock minimum"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_add_sale
+msgid ""
+"The creation of the RMA Lines will be separated according to the lots or "
+"serials selected"
+msgstr ""
+"La création des lignes RMA sera séparée en fonction des lots ou "
+"séries sélectionnés"
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_rma_line_filter
+msgid "To Sell"
+msgstr "A Vendre"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_add_sale
+msgid "Total"
+msgstr ""
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_add_sale
+msgid "Unit of Measure"
+msgstr "Unité de mesure"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__product_uom_id
+msgid "UoM"
+msgstr ""
+
+#. module: rma_sale
+#: model:ir.model.fields,help:rma_sale.field_rma_operation__auto_confirm_rma_sale
+msgid "When a sales is created from an RMA, automatically confirm it"
+msgstr "Lorsqu'une vente est créée à partir d'un RMA, confirmez-la automatiquement"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_order_line_make_sale_order_item__wiz_id
+msgid "Wizard"
+msgstr "Assistant"
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_rma_refund
+msgid "Wizard for RMA Refund"
+msgstr "Assistant de remboursement RMA"
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_rma_add_sale
+msgid "Wizard to add rma lines from SO lines"
+msgstr "Assistant pour ajouter des lignes rma à partir de lignes SO"
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_rma_make_picking_wizard
+msgid "Wizard to create Pickings from rma"
+msgstr "Assistant pour créer des transferts à partir de rma"
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.view_rma_add_sale
+msgid "or"
+msgstr "ou"

--- a/rma_sale/models/rma_order.py
+++ b/rma_sale/models/rma_order.py
@@ -16,7 +16,16 @@ class RmaOrder(models.Model):
             sales = rma.mapped("rma_line_ids.sale_line_id.order_id")
             rma.sale_count = len(sales)
 
+    @api.depends("rma_line_ids", "rma_line_ids.qty_to_sell")
+    def _compute_qty_to_sell(self):
+        for rec in self:
+            rec.qty_to_sell = sum(rec.rma_line_ids.mapped("qty_to_sell"))
+
     sale_count = fields.Integer(compute="_compute_sales_count", string="# of Sales")
+    qty_to_sell = fields.Float(
+        digits="Product Unit of Measure",
+        compute="_compute_qty_to_sell",
+    )
 
     @api.model
     def _get_line_domain(self, rma_id, line):

--- a/rma_sale/models/rma_order.py
+++ b/rma_sale/models/rma_order.py
@@ -11,17 +11,19 @@ class RmaOrder(models.Model):
         "rma_line_ids.sale_line_id",
         "rma_line_ids.sale_line_id.order_id",
     )
-    def _compute_sales_count(self):
+    def _compute_src_sale_count(self):
         for rma in self:
-            sales = rma.mapped("rma_line_ids.sale_line_id.order_id")
-            rma.sale_count = len(sales)
+            src_sales = rma.mapped("rma_line_ids.sale_line_id.order_id")
+            rma.src_sale_count = len(src_sales)
 
     @api.depends("rma_line_ids", "rma_line_ids.qty_to_sell")
     def _compute_qty_to_sell(self):
         for rec in self:
             rec.qty_to_sell = sum(rec.rma_line_ids.mapped("qty_to_sell"))
 
-    sale_count = fields.Integer(compute="_compute_sales_count", string="# of Sales")
+    src_sale_count = fields.Integer(
+        compute="_compute_src_sale_count", string="# of Origin Sales"
+    )
     qty_to_sell = fields.Float(
         digits="Product Unit of Measure",
         compute="_compute_qty_to_sell",

--- a/rma_sale/models/rma_order.py
+++ b/rma_sale/models/rma_order.py
@@ -16,6 +16,16 @@ class RmaOrder(models.Model):
             src_sales = rma.mapped("rma_line_ids.sale_line_id.order_id")
             rma.src_sale_count = len(src_sales)
 
+    @api.depends(
+        "rma_line_ids",
+        "rma_line_ids.sale_line_ids",
+        "rma_line_ids.sale_line_ids.order_id",
+    )
+    def _compute_sale_count(self):
+        for rma in self:
+            sales = rma.mapped("rma_line_ids.sale_line_ids.order_id")
+            rma.sale_count = len(sales)
+
     @api.depends("rma_line_ids", "rma_line_ids.qty_to_sell")
     def _compute_qty_to_sell(self):
         for rec in self:
@@ -28,6 +38,7 @@ class RmaOrder(models.Model):
         digits="Product Unit of Measure",
         compute="_compute_qty_to_sell",
     )
+    sale_count = fields.Integer(compute="_compute_sale_count", string="# of Sales")
 
     @api.model
     def _get_line_domain(self, rma_id, line):
@@ -41,9 +52,16 @@ class RmaOrder(models.Model):
             domain = super()._get_line_domain(rma_id, line)
         return domain
 
+    def action_view_origin_sale_order(self):
+        action = self.env.ref("sale.action_orders")
+        result = action.sudo().read()[0]
+        so_ids = self.mapped("rma_line_ids.sale_line_id.order_id").ids
+        result["domain"] = [("id", "in", so_ids)]
+        return result
+
     def action_view_sale_order(self):
         action = self.env.ref("sale.action_quotations")
         result = action.sudo().read()[0]
-        so_ids = self.mapped("rma_line_ids.sale_line_id.order_id").ids
+        so_ids = self.mapped("rma_line_ids.sale_line_ids.order_id").ids
         result["domain"] = [("id", "in", so_ids)]
         return result

--- a/rma_sale/security/ir.model.access.csv
+++ b/rma_sale/security/ir.model.access.csv
@@ -1,6 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_rma_order_line_make_sale_order_customer_user_item,rma.order.line.make.sale.order.customer.user,model_rma_order_line_make_sale_order,rma.group_rma_customer_user,1,1,1,1
-access_rma_order_line_make_sale_order_supplier_user_item,rma.order.line.make.sale.order.supplier.user,model_rma_order_line_make_sale_order,rma.group_rma_supplier_user,1,1,1,1
+access_rma_order_line_make_sale_order_customer_user_item,rma.order.line.make.sale.order.customer.user,model_rma_make_sale_order,rma.group_rma_customer_user,1,1,1,1
+access_rma_order_line_make_sale_order_supplier_user_item,rma.order.line.make.sale.order.supplier.user,model_rma_make_sale_order,rma.group_rma_supplier_user,1,1,1,1
 access_rma_order_line_make_sale_order_item_customer_user_item,rma.order.line.make.sale.order.item.customer.user,model_rma_order_line_make_sale_order_item,rma.group_rma_customer_user,1,1,1,1
 access_rma_order_line_make_sale_order_item_supplier_user_item,rma.order.line.make.sale.order.item.supplier.user,model_rma_order_line_make_sale_order_item,rma.group_rma_supplier_user,1,1,1,1
 access_rma_add_sale_customer_user_item,rma.add.sale.customer.user,model_rma_add_sale,rma.group_rma_customer_user,1,1,1,1

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -13,7 +13,7 @@ class TestRmaSale(common.SingleTransactionCase):
         cls.rma_line_obj = cls.env["rma.order.line"]
         cls.rma_op_obj = cls.env["rma.operation"]
         cls.rma_add_sale_wiz = cls.env["rma_add_sale"]
-        cls.rma_make_sale_wiz = cls.env["rma.order.line.make.sale.order"]
+        cls.rma_make_sale_wiz = cls.env["rma.make.sale.order"]
         cls.so_obj = cls.env["sale.order"]
         cls.sol_obj = cls.env["sale.order.line"]
         cls.product_obj = cls.env["product.product"]

--- a/rma_sale/views/rma_order_line_view.xml
+++ b/rma_sale/views/rma_order_line_view.xml
@@ -8,7 +8,7 @@
             <div name='button_box' position="inside">
                 <button
                     type="object"
-                    name="action_view_origin_sale_order"
+                    name="action_view_sale_order"
                     class="oe_stat_button"
                     icon="fa-strikethrough"
                     invisible="sale_id == False"
@@ -63,14 +63,14 @@
         <field name="arch" type="xml">
             <header position="inside">
                 <button
-                    name="%(action_rma_order_line_make_sale_order)d"
+                    name="%(action_rma_make_sale_order)d"
                     string="Create Sales Quotation"
                     class="oe_highlight"
                     invisible="qty_to_sell == 0 or qty_to_sell &lt; 0 or state != 'approved' or sale_policy == 'no'"
                     type="action"
                 />
                 <button
-                    name="%(action_rma_order_line_make_sale_order)d"
+                    name="%(action_rma_make_sale_order)d"
                     string="Create Sales Quotation"
                     invisible="qty_to_sell &gt; 0 or state != 'approved' or sale_policy == 'no'"
                     type="action"

--- a/rma_sale/views/rma_order_line_view.xml
+++ b/rma_sale/views/rma_order_line_view.xml
@@ -5,6 +5,21 @@
         <field name="model">rma.order.line</field>
         <field name="inherit_id" ref="rma.view_rma_line_form" />
         <field name="arch" type="xml">
+            <header position="inside">
+                <button
+                    name="%(rma_sale.action_rma_make_sale_order)d"
+                    string="Create Sales Quotation"
+                    class="oe_highlight"
+                    invisible="qty_to_sell == 0 or qty_to_sell &lt; 0 or state != 'approved' or sale_policy == 'no'"
+                    type="action"
+                />
+                <button
+                    name="%(rma_sale.action_rma_make_sale_order)d"
+                    string="Create Sales Quotation"
+                    invisible="qty_to_sell &gt; 0 or state != 'approved' or sale_policy == 'no'"
+                    type="action"
+                />
+            </header>
             <div name='button_box' position="inside">
                 <button
                     type="object"
@@ -53,29 +68,6 @@
                     />
                 </page>
             </notebook>
-        </field>
-    </record>
-
-    <record id="view_rma_line_button_sale_form" model="ir.ui.view">
-        <field name="name">rma.order.line.form</field>
-        <field name="model">rma.order.line</field>
-        <field name="inherit_id" ref="rma.view_rma_line_button_form" />
-        <field name="arch" type="xml">
-            <header position="inside">
-                <button
-                    name="%(action_rma_make_sale_order)d"
-                    string="Create Sales Quotation"
-                    class="oe_highlight"
-                    invisible="qty_to_sell == 0 or qty_to_sell &lt; 0 or state != 'approved' or sale_policy == 'no'"
-                    type="action"
-                />
-                <button
-                    name="%(action_rma_make_sale_order)d"
-                    string="Create Sales Quotation"
-                    invisible="qty_to_sell &gt; 0 or state != 'approved' or sale_policy == 'no'"
-                    type="action"
-                />
-            </header>
         </field>
     </record>
 

--- a/rma_sale/views/rma_order_line_view.xml
+++ b/rma_sale/views/rma_order_line_view.xml
@@ -23,10 +23,10 @@
             <div name='button_box' position="inside">
                 <button
                     type="object"
-                    name="action_view_sale_order"
+                    name="action_view_origin_sale_order"
                     class="oe_stat_button"
                     icon="fa-strikethrough"
-                    invisible="sale_id == False"
+                    invisible="sale_line_id == False"
                     string="Origin Sale Order"
                 />
                 <button

--- a/rma_sale/views/rma_order_view.xml
+++ b/rma_sale/views/rma_order_view.xml
@@ -20,6 +20,32 @@
             <xpath expr="//field[@name='rma_line_ids']/list" position="inside">
                 <field name="sale_policy" invisible="True" />
             </xpath>
+            <xpath expr="//field[@name='qty_to_deliver']" position="after">
+                <field name="qty_to_sell" invisible="1" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_rma_button_sale_form" model="ir.ui.view">
+        <field name="name">rma.order.form</field>
+        <field name="model">rma.order</field>
+        <field name="inherit_id" ref="rma.view_rma_button_form" />
+        <field name="arch" type="xml">
+            <header position="inside">
+                <button
+                    name="%(action_rma_make_sale_order)d"
+                    string="Create Sales Quotation"
+                    class="oe_highlight"
+                    attrs="{'invisible':['|', '|', ('qty_to_sell', '=', 0), ('qty_to_sell', '&lt;', 0), ('state', '!=', 'approved')]}"
+                    type="action"
+                />
+                <button
+                    name="%(action_rma_make_sale_order)d"
+                    string="Create Sales Quotation"
+                    attrs="{'invisible':['|', ('qty_to_sell', '>', 0), ('state', '!=', 'approved')]}"
+                    type="action"
+                />
+            </header>
         </field>
     </record>
 </odoo>

--- a/rma_sale/views/rma_order_view.xml
+++ b/rma_sale/views/rma_order_view.xml
@@ -5,24 +5,26 @@
         <field name="model">rma.order</field>
         <field name="inherit_id" ref="rma.view_rma_form" />
         <field name="arch" type="xml">
-            <xpath expr="//header" position="inside">
+            <xpath
+                expr="//header/button[@name='%(rma.action_rma_add_stock_move_customer)d']"
+                position="after"
+            >
                 <button
                     name="%(rma_sale.action_rma_add_sale)d"
                     string="Add From Sale Order"
                     type="action"
                     invisible="type != 'customer'"
                 />
+            </xpath>
+            <xpath
+                expr="//header/button[@name='%(rma_account.action_rma_refund)d']"
+                position="after"
+            >
                 <button
                     name="%(rma_sale.action_rma_make_sale_order)d"
                     string="Create Sales Quotation"
                     class="oe_highlight"
                     invisible="qty_to_sell &lt;= 0 or state != 'approved'"
-                    type="action"
-                />
-                <button
-                    name="%(rma_sale.action_rma_make_sale_order)d"
-                    string="Create Sales Quotation"
-                    invisible="qty_to_sell &gt; 0 or state != 'approved'"
                     type="action"
                 />
             </xpath>
@@ -33,9 +35,9 @@
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
                     groups="sales_team.group_sale_salesman"
-                    invisible="type != 'customer'"
+                    invisible="type != 'customer' or src_sale_count == 0"
                 >
-                    <field name="sale_count" widget="statinfo" string="Origin SO" />
+                    <field name="src_sale_count" widget="statinfo" string="Origin SO" />
                 </button>
             </div>
             <xpath expr="//field[@name='rma_line_ids']/list" position="inside">

--- a/rma_sale/views/rma_order_view.xml
+++ b/rma_sale/views/rma_order_view.xml
@@ -31,13 +31,27 @@
             <div name="button_box" position="inside">
                 <button
                     type="object"
-                    name="action_view_sale_order"
+                    name="action_view_origin_sale_order"
                     class="oe_stat_button"
                     icon="fa-pencil-square-o"
                     groups="sales_team.group_sale_salesman"
-                    invisible="type != 'customer' or src_sale_count == 0"
+                    invisible="src_sale_count == 0"
                 >
-                    <field name="src_sale_count" widget="statinfo" string="Origin SO" />
+                    <field
+                        name="src_sale_count"
+                        widget="statinfo"
+                        string="Origin Sale Order"
+                    />
+                </button>
+                <button
+                    type="object"
+                    name="action_view_sale_order"
+                    class="oe_stat_button"
+                    icon="fa-strikethrough"
+                    attrs="{'invisible': [('sale_count', '=', 0)]}"
+                    groups="sales_team.group_sale_salesman_all_leads"
+                >
+                    <field name="sale_count" widget="statinfo" string="Sales Orders" />
                 </button>
             </div>
             <xpath expr="//field[@name='rma_line_ids']/list" position="inside">

--- a/rma_sale/views/rma_order_view.xml
+++ b/rma_sale/views/rma_order_view.xml
@@ -48,7 +48,7 @@
                     name="action_view_sale_order"
                     class="oe_stat_button"
                     icon="fa-strikethrough"
-                    attrs="{'invisible': [('sale_count', '=', 0)]}"
+                    invisible="sale_count == 0"
                     groups="sales_team.group_sale_salesman_all_leads"
                 >
                     <field name="sale_count" widget="statinfo" string="Sales Orders" />

--- a/rma_sale/views/rma_order_view.xml
+++ b/rma_sale/views/rma_order_view.xml
@@ -5,6 +5,27 @@
         <field name="model">rma.order</field>
         <field name="inherit_id" ref="rma.view_rma_form" />
         <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button
+                    name="%(rma_sale.action_rma_add_sale)d"
+                    string="Add From Sale Order"
+                    type="action"
+                    invisible="type != 'customer'"
+                />
+                <button
+                    name="%(rma_sale.action_rma_make_sale_order)d"
+                    string="Create Sales Quotation"
+                    class="oe_highlight"
+                    invisible="qty_to_sell &lt;= 0 or state != 'approved'"
+                    type="action"
+                />
+                <button
+                    name="%(rma_sale.action_rma_make_sale_order)d"
+                    string="Create Sales Quotation"
+                    invisible="qty_to_sell &gt; 0 or state != 'approved'"
+                    type="action"
+                />
+            </xpath>
             <div name="button_box" position="inside">
                 <button
                     type="object"
@@ -23,29 +44,6 @@
             <xpath expr="//field[@name='qty_to_deliver']" position="after">
                 <field name="qty_to_sell" invisible="1" />
             </xpath>
-        </field>
-    </record>
-
-    <record id="view_rma_button_sale_form" model="ir.ui.view">
-        <field name="name">rma.order.form</field>
-        <field name="model">rma.order</field>
-        <field name="inherit_id" ref="rma.view_rma_button_form" />
-        <field name="arch" type="xml">
-            <header position="inside">
-                <button
-                    name="%(action_rma_make_sale_order)d"
-                    string="Create Sales Quotation"
-                    class="oe_highlight"
-                    attrs="{'invisible':['|', '|', ('qty_to_sell', '=', 0), ('qty_to_sell', '&lt;', 0), ('state', '!=', 'approved')]}"
-                    type="action"
-                />
-                <button
-                    name="%(action_rma_make_sale_order)d"
-                    string="Create Sales Quotation"
-                    attrs="{'invisible':['|', ('qty_to_sell', '>', 0), ('state', '!=', 'approved')]}"
-                    type="action"
-                />
-            </header>
         </field>
     </record>
 </odoo>

--- a/rma_sale/wizards/__init__.py
+++ b/rma_sale/wizards/__init__.py
@@ -1,4 +1,4 @@
-from . import rma_order_line_make_sale_order
+from . import rma_make_sale_order
 from . import rma_make_picking
 from . import rma_refund
 from . import rma_add_sale

--- a/rma_sale/wizards/rma_add_sale.xml
+++ b/rma_sale/wizards/rma_add_sale.xml
@@ -98,20 +98,4 @@
             eval="[(4, ref('rma.group_rma_customer_user')), (4, ref('rma.group_rma_customer_user'))]"
         />
     </record>
-
-    <record id="view_rma_add_sale_form" model="ir.ui.view">
-        <field name="name">rma.order.form - sale wizard</field>
-        <field name="model">rma.order</field>
-        <field name="inherit_id" ref="rma.view_rma_form" />
-        <field name="arch" type="xml">
-            <xpath expr="//header" position="inside">
-                <button
-                    name="%(action_rma_add_sale)d"
-                    string="Add From Sale Order"
-                    type="action"
-                    invisible="type != 'customer'"
-                />
-            </xpath>
-        </field>
-    </record>
 </odoo>

--- a/rma_sale/wizards/rma_add_sale.xml
+++ b/rma_sale/wizards/rma_add_sale.xml
@@ -14,13 +14,13 @@
                     <field
                         name="sale_id"
                         domain="[
-                           ('partner_id','=',partner_id), (('state','not in',['draft','cancel']))]"
+                           ('partner_id','=',partner_id), ('state','not in',['draft','cancel']), ('picking_ids.state', '=', 'done')]"
                         context="{'partner_id': partner_id}"
                     />
                 </group>
                 <field
                     name="sale_line_ids"
-                    domain="[('order_id', '=', sale_id)]"
+                    domain="[('order_id', '=', sale_id), ('move_ids.state', '=', 'done')]"
                     string="Sale Order Lines"
                 >
                     <list>

--- a/rma_sale/wizards/rma_make_sale_order.py
+++ b/rma_sale/wizards/rma_make_sale_order.py
@@ -1,12 +1,13 @@
 # Copyright 2020 ForgeFlow S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
-from odoo import _, api, exceptions, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
-class RmaLineMakeSaleOrder(models.TransientModel):
-    _name = "rma.order.line.make.sale.order"
-    _description = "Make Sales Order from RMA Line"
+class RmaMakeSaleOrder(models.TransientModel):
+    _name = "rma.make.sale.order"
+    _description = "Make Sales Order from RMA"
 
     partner_id = fields.Many2one(
         comodel_name="res.partner",
@@ -43,24 +44,33 @@ class RmaLineMakeSaleOrder(models.TransientModel):
 
     @api.model
     def default_get(self, fields_list):
+        context = self._context.copy()
         res = super().default_get(fields_list)
         rma_line_obj = self.env["rma.order.line"]
-        rma_line_ids = self.env.context["active_ids"] or []
-        active_model = self.env.context["active_model"]
+        rma_obj = self.env["rma.order"]
+        active_ids = context.get("active_ids") or []
+        active_model = context.get("active_model")
 
-        if not rma_line_ids:
+        if not active_ids:
             return res
-        assert active_model == "rma.order.line", "Bad context propagation"
+        assert active_model in [
+            "rma.order.line",
+            "rma.order",
+        ], "Bad context propagation"
 
         items = []
-        lines = rma_line_obj.browse(rma_line_ids)
+        if active_model == "rma.order":
+            rma = rma_obj.browse(active_ids)
+            lines = rma.rma_line_ids
+        else:
+            lines = rma_line_obj.browse(active_ids)
         for line in lines:
             items.append([0, 0, self._prepare_item(line)])
         customers = lines.mapped("partner_id")
         if len(customers) == 1:
             res["partner_id"] = customers.id
         else:
-            raise exceptions.Warning(
+            raise ValidationError(
                 _(
                     "Only RMA lines from the same partner can be processed at "
                     "the same time"
@@ -72,7 +82,7 @@ class RmaLineMakeSaleOrder(models.TransientModel):
     @api.model
     def _prepare_sale_order(self, line):
         if not self.partner_id:
-            raise exceptions.Warning(_("Enter a customer."))
+            raise ValidationError(_("Enter a customer."))
         customer = self.partner_id
         auto = self.env["account.fiscal.position"].search(
             [("auto_apply", "=", True), ("country_id", "=", customer.country_id.id)],
@@ -83,8 +93,11 @@ class RmaLineMakeSaleOrder(models.TransientModel):
             fiscal_position = customer.property_account_position_id
         elif auto:
             fiscal_position = auto
+        origin = line.name
+        if self.env.context.get("active_model") == "rma.order":
+            origin = line.rma_id.name
         data = {
-            "origin": line.name,
+            "origin": origin,
             "partner_id": customer.id,
             "warehouse_id": line.out_warehouse_id.id,
             "company_id": line.company_id.id,
@@ -118,19 +131,20 @@ class RmaLineMakeSaleOrder(models.TransientModel):
         sale_obj = self.env["sale.order"]
         so_line_obj = self.env["sale.order.line"]
         sale = False
-
         for item in self.item_ids:
-            line = item.line_id
             if item.product_qty <= 0.0:
-                raise exceptions.Warning(_("Enter a positive quantity."))
+                raise ValidationError(_("Enter a positive quantity."))
 
             if self.sale_order_id:
                 sale = self.sale_order_id
             if not sale:
+                line = item.line_id
                 po_data = self._prepare_sale_order(line)
                 sale = sale_obj.create(po_data)
-                sale.name = sale.name + " - " + line.name
-
+                rma = line
+                if self.env.context.get("active_model") == "rma.order":
+                    rma = line.rma_id
+                sale.name = sale.name + " - " + rma.name
             so_line_data = self._prepare_sale_order_line(sale, item)
             sale_line = so_line_obj.create(so_line_data)
             self._post_process_sale_order(item, sale_line)
@@ -146,9 +160,7 @@ class RmaLineMakeSaleOrderItem(models.TransientModel):
     _name = "rma.order.line.make.sale.order.item"
     _description = "RMA Line Make Sale Order Item"
 
-    wiz_id = fields.Many2one(
-        comodel_name="rma.order.line.make.sale.order", string="Wizard"
-    )
+    wiz_id = fields.Many2one(comodel_name="rma.make.sale.order", string="Wizard")
     line_id = fields.Many2one(
         comodel_name="rma.order.line", string="RMA Line", compute="_compute_line_id"
     )
@@ -166,11 +178,17 @@ class RmaLineMakeSaleOrderItem(models.TransientModel):
 
     def _compute_line_id(self):
         rma_line_obj = self.env["rma.order.line"]
+        rma_obj = self.env["rma.order"]
+        active_ids = self.env.context.get("active_ids") or []
+        active_model = self.env.context.get("active_model")
         for rec in self:
-            if not self.env.context["active_ids"]:
+            if not active_ids:
                 return
-            rma_line_ids = self.env.context["active_ids"] or []
-            lines = rma_line_obj.browse(rma_line_ids)
+            if active_model == "rma.order":
+                rma = rma_obj.browse(active_ids)
+                lines = rma.rma_line_ids
+            else:
+                lines = rma_line_obj.browse(active_ids)
             rec.line_id = lines[0]
 
     @api.onchange("product_id")

--- a/rma_sale/wizards/rma_make_sale_order_view.xml
+++ b/rma_sale/wizards/rma_make_sale_order_view.xml
@@ -4,7 +4,7 @@
 <odoo>
     <record id="view_rma_order_line_make_sale_order" model="ir.ui.view">
         <field name="name">RMA Line Make Sale Order</field>
-        <field name="model">rma.order.line.make.sale.order</field>
+        <field name="model">rma.make.sale.order</field>
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form string="Create Quotation">
@@ -50,10 +50,10 @@
         </field>
     </record>
 
-    <record id="action_rma_order_line_make_sale_order" model="ir.actions.act_window">
+    <record id="action_rma_make_sale_order" model="ir.actions.act_window">
         <field name="name">Create Sales Quotation</field>
         <field name="type">ir.actions.act_window</field>
-        <field name="res_model">rma.order.line.make.sale.order</field>
+        <field name="res_model">rma.make.sale.order</field>
         <field name="view_mode">form</field>
         <field name="view_id" ref="view_rma_order_line_make_sale_order" />
         <field name="target">new</field>


### PR DESCRIPTION
This is a port of https://github.com/ForgeFlow/stock-rma/pull/508 (which is approved already)
But splitted in 3 PR, one per module (rma, rma_account, rma_sale)
The goal is to merge it in this recent version since it may seems a lot of change for a stable version (but it is actually very few changes, things is some refactore in views was also done (move rma.order and rma.order.line view override from wizard to view folder).

This PR on rma add 1 button on RMA group :
- Sale Order creation from rma group
- Fix some sale smart button on rma group

@AaronHForgeFlow @sebastienbeau @JasminSForgeFlow