### PR TITLE
[17.0][FIX] rma: fixed inconsistencies with delivery quantities

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -122,7 +122,12 @@ class RmaOrderLine(models.Model):
                     continue
                 elif direction == "in" and move.move_dest_ids:
                     continue
-                qty += product_obj._compute_quantity(move.product_uom_qty, rec.uom_id)
+                if move.state == "done":
+                    qty += product_obj._compute_quantity(move.quantity, rec.uom_id)
+                else:
+                    qty += product_obj._compute_quantity(
+                        move.product_uom_qty, rec.uom_id
+                    )
             return qty
 
     @api.depends(
@@ -159,9 +164,13 @@ class RmaOrderLine(models.Model):
         for rec in self:
             rec.qty_to_deliver = 0.0
             if rec.delivery_policy == "ordered":
-                rec.qty_to_deliver = rec.product_qty - rec.qty_delivered
+                rec.qty_to_deliver = max(
+                    rec.product_qty - rec.qty_outgoing - rec.qty_delivered, 0
+                )
             elif rec.delivery_policy == "received":
-                rec.qty_to_deliver = rec.qty_received - rec.qty_delivered
+                rec.qty_to_deliver = max(
+                    rec.qty_received - rec.qty_outgoing - rec.qty_delivered, 0
+                )
 
     @api.depends("move_ids", "move_ids.state", "type")
     def _compute_qty_incoming(self):
@@ -181,7 +190,8 @@ class RmaOrderLine(models.Model):
     def _compute_qty_outgoing(self):
         for rec in self:
             qty = rec._get_rma_move_qty(
-                ("draft", "confirmed", "assigned", "waiting"), direction="out"
+                ("draft", "confirmed", "assigned", "waiting", "partially_available"),
+                direction="out",
             )
             rec.qty_outgoing = qty
 

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -680,7 +680,7 @@ class TestRma(common.TransactionCase):
         # product specific
         self._check_equal_quantity(
             lines.filtered(lambda x: x.product_id == self.product_1).qty_to_deliver,
-            3,
+            0,
             "Wrong qty to_deliver",
         )
         self._check_equal_quantity(
@@ -690,7 +690,7 @@ class TestRma(common.TransactionCase):
         )
         self._check_equal_quantity(
             lines.filtered(lambda x: x.product_id == self.product_2).qty_to_deliver,
-            5,
+            0,
             "Wrong qty to_deliver",
         )
         self._check_equal_quantity(
@@ -700,7 +700,7 @@ class TestRma(common.TransactionCase):
         )
         self._check_equal_quantity(
             lines.filtered(lambda x: x.product_id == self.product_3).qty_to_deliver,
-            2,
+            0,
             "Wrong qty to_deliver",
         )
         self._check_equal_quantity(
@@ -913,7 +913,7 @@ class TestRma(common.TransactionCase):
         )
         self._check_equal_quantity(
             lines.filtered(lambda x: x.product_id == self.product_1).qty_to_deliver,
-            3,
+            0,
             "Wrong qty_to_deliver",
         )
         self._check_equal_quantity(
@@ -923,7 +923,7 @@ class TestRma(common.TransactionCase):
         )
         self._check_equal_quantity(
             lines.filtered(lambda x: x.product_id == self.product_2).qty_to_deliver,
-            5,
+            0,
             "Wrong qty_to_deliver",
         )
         self._check_equal_quantity(
@@ -933,7 +933,7 @@ class TestRma(common.TransactionCase):
         )
         self._check_equal_quantity(
             lines.filtered(lambda x: x.product_id == self.product_3).qty_to_deliver,
-            2,
+            0,
             "Wrong qty_to_deliver",
         )
         self.assertEqual(


### PR DESCRIPTION
This pr includes the following fixes:

- Fix the "quantity to deliver" calculation and prevent it from being negative.
- Use "quantity" instead of "demand" to calculate the delivered quantity.

Related issues: https://github.com/ForgeFlow/stock-rma/issues/628 https://github.com/ForgeFlow/stock-rma/issues/629