### PR TITLE
[16.0][IMP] rma: allow to specify custom supplier location.

### DIFF
--- a/rma/models/rma_operation.py
+++ b/rma/models/rma_operation.py
@@ -80,6 +80,12 @@ class RmaOperation(models.Model):
         default=lambda self: self._default_warehouse_id(),
     )
     location_id = fields.Many2one("stock.location", "Send To This Company Location")
+    location_supplier_id = fields.Many2one(
+        comodel_name="stock.location",
+        string="Send To This Supplier Location",
+        help="You can specify any supplier location, the absence of any filter is "
+        "on purpose as you could define 'internal' supplier locations",
+    )
     type = fields.Selection(
         [("customer", "Customer"), ("supplier", "Supplier")],
         string="Used in RMA of this type",

--- a/rma/models/rma_order.py
+++ b/rma/models/rma_order.py
@@ -147,6 +147,10 @@ class RmaOrder(models.Model):
         comodel_name="stock.location",
         string="Send To This Company Location",
     )
+    location_supplier_id = fields.Many2one(
+        comodel_name="stock.location",
+        string="Send To This Supplier Location",
+    )
     customer_to_supplier = fields.Boolean("The customer will send to the supplier")
     supplier_to_customer = fields.Boolean("The supplier will send to the customer")
     supplier_address_id = fields.Many2one(
@@ -187,6 +191,7 @@ class RmaOrder(models.Model):
             self.location_id = (
                 self.operation_default_id.location_id or self.in_warehouse_id.lot_rma_id
             )
+            self.location_supplier_id = self.operation_default_id.location_supplier_id
             self.customer_to_supplier = self.operation_default_id.customer_to_supplier
             self.supplier_to_customer = self.operation_default_id.supplier_to_customer
             self.in_route_id = self.operation_default_id.in_route_id

--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -442,6 +442,14 @@ class RmaOrderLine(models.Model):
         states={"draft": [("readonly", False)]},
         default=lambda self: self._default_location_id(),
     )
+    location_supplier_id = fields.Many2one(
+        comodel_name="stock.location",
+        string="Send To This Supplier Location",
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+        help="If no location is selected, the one define in the delivery "
+        "address will be used, which by default is 'Vendors' location.",
+    )
     customer_rma_id = fields.Many2one(
         "rma.order.line", string="Customer RMA line", ondelete="cascade"
     )
@@ -759,6 +767,9 @@ class RmaOrderLine(models.Model):
             self.rma_id.location_id
             or self.operation_id.location_id
             or self.in_warehouse_id.lot_rma_id
+        )
+        self.location_supplier_id = (
+            self.rma_id.location_supplier_id or self.operation_id.location_supplier_id
         )
         self.in_route_id = self.rma_id.in_route_id or self.operation_id.in_route_id
         self.out_route_id = self.rma_id.out_route_id or self.operation_id.out_route_id

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -1633,3 +1633,79 @@ class TestRma(common.TransactionCase):
             mv.qty_done = mv.reserved_uom_qty
         picking._action_done()
         self.assertEqual(picking.state, "done", "Final picking should has done state")
+
+    def test_13_custom_supplier_location(self):
+        # Test we can use custom supplier locations
+        supplier_loc = self.env["stock.location"].create(
+            {
+                "name": "Supplier Location",
+                "usage": "supplier",
+            }
+        )
+        custom_rma_supplier_route = self.env["stock.route"].create(
+            {
+                "name": "RMA Supplier Custom",
+                "product_selectable": True,
+                "company_id": False,
+                "rma_selectable": True,
+            }
+        )
+        picking_type_to_sub = self.env["stock.picking.type"].create(
+            {
+                "name": "RMA to custom",
+                "code": "internal",
+                "warehouse_id": self.wh.id,
+                "sequence_code": "RMA-CUST",
+                "default_location_src_id": self.stock_rma_location.id,
+                "default_location_dest_id": supplier_loc.id,
+            }
+        )
+        picking_type_from_sub = self.env["stock.picking.type"].create(
+            {
+                "name": "custom to RMA",
+                "code": "internal",
+                "warehouse_id": self.wh.id,
+                "sequence_code": "CUST-RMA",
+                "default_location_src_id": supplier_loc.id,
+                "default_location_dest_id": self.stock_rma_location.id,
+            }
+        )
+        self.env["stock.rule"].create(
+            {
+                "name": "RMA to custom",
+                "route_id": custom_rma_supplier_route.id,
+                "action": "pull",
+                "picking_type_id": picking_type_to_sub.id,
+                "location_src_id": self.stock_rma_location.id,
+                "location_dest_id": supplier_loc.id,
+                "procure_method": "make_to_stock",
+            }
+        )
+        self.env["stock.rule"].create(
+            {
+                "name": "custom to RMA",
+                "route_id": custom_rma_supplier_route.id,
+                "action": "pull",
+                "picking_type_id": picking_type_from_sub.id,
+                "location_src_id": supplier_loc.id,
+                "location_dest_id": self.stock_rma_location.id,
+                "procure_method": "make_to_stock",
+            }
+        )
+        products2move = [
+            (self.product_1, 1),
+        ]
+        rma_supplier_id = self._create_rma_from_move(
+            products2move,
+            "supplier",
+            self.env.ref("base.res_partner_2"),
+            dropship=False,
+        )
+        rma = rma_supplier_id.rma_line_ids
+        rma.out_route_id = custom_rma_supplier_route
+        rma.location_supplier_id = supplier_loc
+        rma.action_rma_to_approve()
+        self._deliver_rma(rma)
+        res = rma.action_view_out_shipments()
+        picking = self.env["stock.picking"].browse(res["res_id"])
+        self.assertEqual(picking.location_dest_id, supplier_loc)

--- a/rma/views/rma_operation_view.xml
+++ b/rma/views/rma_operation_view.xml
@@ -61,6 +61,7 @@
                         <group name="outbound" string="Outbound">
                             <field name="out_route_id" />
                             <field name="out_warehouse_id" />
+                            <field name="location_supplier_id" />
                             <field
                                 name="supplier_to_customer"
                                 attrs="{'invisible':[('type', '=', 'customer')]}"

--- a/rma/views/rma_order_line_view.xml
+++ b/rma/views/rma_order_line_view.xml
@@ -288,6 +288,7 @@
                                 </group>
                                 <group name="outbound" string="Outbound">
                                     <field name="out_warehouse_id" />
+                                    <field name="location_supplier_id" />
                                     <field
                                     name="out_route_id"
                                     groups="stock.group_adv_location"

--- a/rma/wizards/rma_make_picking.py
+++ b/rma/wizards/rma_make_picking.py
@@ -99,24 +99,35 @@ class RmaMakePicking(models.TransientModel):
         elif a_type == "customer":
             return delivery_address_id.property_stock_customer
 
+    def _get_procurement_location(self, line, picking_type, delivery_address_id):
+        location = False
+        if picking_type == "incoming":
+            if line.customer_to_supplier:
+                location = self._get_address_location(delivery_address_id, "supplier")
+            else:
+                location = line.location_id
+        elif picking_type == "outgoing":
+            if line.supplier_to_customer:
+                location = self._get_address_location(delivery_address_id, "customer")
+            else:
+                location = line.location_supplier_id or self._get_address_location(
+                    delivery_address_id, line.type
+                )
+        return location
+
     @api.model
     def _get_procurement_data(self, item, group, qty, picking_type):
         line = item.line_id
         delivery_address_id = self._get_address(item)
         date_planned = fields.Datetime.now()
         location, warehouse, route = False, False, False
+        location = self._get_procurement_location(
+            line, picking_type, delivery_address_id
+        )
         if picking_type == "incoming":
-            if line.customer_to_supplier:
-                location = self._get_address_location(delivery_address_id, "supplier")
-            else:
-                location = line.location_id
             warehouse = line.in_warehouse_id
             route = line.in_route_id
         elif picking_type == "outgoing":
-            if line.supplier_to_customer:
-                location = self._get_address_location(delivery_address_id, "customer")
-            else:
-                location = self._get_address_location(delivery_address_id, line.type)
             warehouse = line.out_warehouse_id
             route = line.out_route_id
             if line.product_id.sale_delay:

--- a/rma/wizards/rma_order_line_make_supplier_rma_view.xml
+++ b/rma/wizards/rma_order_line_make_supplier_rma_view.xml
@@ -8,12 +8,16 @@
         <field name="type">form</field>
         <field name="arch" type="xml">
              <form string="Create Supplier RMA">
-                 <separator string="Existing Supplier RMA to update:" />
+                 <separator
+                    string="Existing Supplier RMA to update:"
+                    groups="rma.group_rma_groups"
+                />
                  <newline />
                  <group>
                     <field
                         name="supplier_rma_id"
                         domain="[('partner_id', '=', partner_id)]"
+                        groups="rma.group_rma_groups"
                     />
                  </group>
                  <newline />


### PR DESCRIPTION
Currently the rma reception location can be specified. I propose to so the same for the destination locations. This is useful when you want to deliver to a different location than the specified in the property of the delivery address, for example, for specific subcontracting location.

Currently you are forced to use the property of the delivery address but you may need different locations for the same supplier depending on the RMA:

https://github.com/ForgeFlow/stock-rma/blob/16.0/rma/wizards/rma_make_picking.py#L98

For incoming pickings you currently can specify the location: https://github.com/ForgeFlow/stock-rma/blob/16.0/rma/wizards/rma_make_picking.py#L112

I also took the chance to:

- Also add a hook for the procurement location calculation.
- Also a minor fix when creating a supplier RMA from a customer RMA, hiding the specific part when RMA groups are not activated.

@LoisRForgeFlow 