### PR TITLE
[18.0][FIX] ci: disable automatic pot generation

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.29
+_commit: v1.32
 _src_path: https://github.com/OCA/oca-addons-repo-template.git
 additional_ruff_rules: []
 ci: GitHub
@@ -9,7 +9,7 @@ generate_requirements_txt: true
 github_check_license: true
 github_ci_extra_env: {}
 github_enable_codecov: true
-github_enable_makepot: true
+github_enable_makepot: false
 github_enable_stale_action: true
 github_enforce_dev_status_compatibility: true
 include_wkhtmltopdf: false
@@ -24,3 +24,4 @@ repo_slug: stock-rma
 repo_website: https://github.com/ForgeFlow
 use_pyproject_toml: true
 use_ruff: true
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo18.0:latest
             name: test with Odoo
-            makepot: "true"
+            makepot: "false"
     services:
       postgres:
         image: postgres:12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,7 @@ repos:
         additional_dependencies:
           - "eslint@9.12.0"
           - "eslint-plugin-jsdoc@50.3.1"
+          - "globals@16.0.0"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,3 +1,4 @@
+var globals = require('globals');
 jsdoc = require("eslint-plugin-jsdoc");
 
 const config = [{
@@ -16,6 +17,8 @@ const config = [{
             openerp: "readonly",
             owl: "readonly",
             luxon: "readonly",
+            QUnit: "readonly",
+            ...globals.browser,
         },
 
         ecmaVersion: 2024,
@@ -191,7 +194,7 @@ const config = [{
     },
 
 }, {
-    files: ["**/*.esm.js"],
+    files: ["**/*.esm.js", "**/*test.js"],
 
     languageOptions: {
         ecmaVersion: 2024,


### PR DESCRIPTION
CI was failing on every merge to main branch because of this. In previous versions it was not enabled either.

![image](https://github.com/user-attachments/assets/163bdcb4-23a6-4bb0-9fd0-5708e21968cc)
