### PR TITLE
[16.0][rma] Fix dependency of qty_to_deliver field + take into account production usage as internal to compute outgoing moves

### DIFF
--- a/rma/models/rma_order_line.py
+++ b/rma/models/rma_order_line.py
@@ -77,7 +77,7 @@ class RmaOrderLine(models.Model):
         for move in self.move_ids:
             first_usage = move._get_first_usage()
             last_usage = move._get_last_usage()
-            if first_usage == "internal" and last_usage != "internal":
+            if first_usage in ("internal", "production") and last_usage != "internal":
                 moves |= move
             elif first_usage == "supplier" and last_usage == "customer":
                 moves |= moves
@@ -156,6 +156,7 @@ class RmaOrderLine(models.Model):
         "type",
         "qty_delivered",
         "qty_received",
+        "qty_outgoing",
     )
     def _compute_qty_to_deliver(self):
         for rec in self:


### PR DESCRIPTION
Replace https://github.com/ForgeFlow/stock-rma/pull/619 now that https://github.com/ForgeFlow/stock-rma/pull/654 has been merged

@LoisRForgeFlow @AaronHForgeFlow @ArnauCForgeFlow 