### PR TITLE
[18.0][IMP] Display product display name on incoming/outgoing stock move instead of rma ref

### DIFF
--- a/rma/wizards/rma_make_picking.py
+++ b/rma/wizards/rma_make_picking.py
@@ -147,7 +147,7 @@ class RmaMakePicking(models.TransientModel):
         if not warehouse:
             raise ValidationError(self.env._("No warehouse specified"))
         procurement_data = {
-            "name": line.rma_id and line.rma_id.name or line.name,
+            "name": line.product_id.display_name,
             "group_id": group,
             "origin": group and group.name or line.name,
             "warehouse_id": warehouse,
@@ -195,7 +195,7 @@ class RmaMakePicking(models.TransientModel):
                 qty,
                 item.line_id.product_id.product_tmpl_id.uom_id,
                 values.get("location_id"),
-                values.get("origin"),
+                values.get("name"),
                 values.get("origin"),
                 self.env.company,
                 values,


### PR DESCRIPTION
Fwport of #603 

@florian-dacosta it was actually missing in v18 too.