### PR TITLE
[16.0][IMP] rma_purchase: allow to specify picking type

### DIFF
--- a/rma_purchase/wizards/rma_order_line_make_purchase_order.py
+++ b/rma_purchase/wizards/rma_order_line_make_purchase_order.py
@@ -16,6 +16,11 @@ class RmaLineMakePurchaseOrder(models.TransientModel):
         required=False,
         readonly=1,
     )
+    picking_type_id = fields.Many2one(
+        comodel_name="stock.picking.type",
+        string="Picking Type",
+        default=lambda self: self._default_picking_type(),
+    )
     item_ids = fields.One2many(
         comodel_name="rma.order.line.make.purchase.order.item",
         inverse_name="wiz_id",
@@ -27,6 +32,12 @@ class RmaLineMakePurchaseOrder(models.TransientModel):
         required=False,
         domain=[("state", "=", "draft")],
     )
+
+    @api.model
+    def _default_picking_type(self):
+        return self.env["purchase.order"]._get_picking_type(
+            company_id=self.env.company.id
+        )
 
     @api.model
     def _prepare_item(self, line):
@@ -77,6 +88,9 @@ class RmaLineMakePurchaseOrder(models.TransientModel):
             "origin": "",
             "partner_id": supplier.id,
             "company_id": item.line_id.company_id.id,
+            "picking_type_id": self.picking_type_id.id
+            if self.picking_type_id
+            else False,
         }
         return data
 

--- a/rma_purchase/wizards/rma_order_line_make_purchase_order_view.xml
+++ b/rma_purchase/wizards/rma_order_line_make_purchase_order_view.xml
@@ -20,6 +20,7 @@
                  <newline />
                  <group>
                      <field name="partner_id" />
+                     <field name="picking_type_id" />
                  </group>
                  <newline />
                  <group>


### PR DESCRIPTION
For example, I want to purchase on a specific warehouse or location. My use case is subcontractors are sending the products from specific location depending on the purpose of the purchase

![image](https://github.com/user-attachments/assets/abec5326-9292-4aa2-aad9-f227dc38ca7b)

Is it ok to put this in the base module? or it may confuse users?
