### PR TITLE
[16.0][FIX] rma_purchase & rma_sale: warning messages instead of errors

### DIFF
--- a/rma_purchase/wizards/rma_order_line_make_purchase_order.py
+++ b/rma_purchase/wizards/rma_order_line_make_purchase_order.py
@@ -104,7 +104,7 @@ class RmaLineMakePurchaseOrder(models.TransientModel):
 
         for item in self.item_ids:
             if item.product_qty <= 0.0:
-                raise exceptions.Warning(_("Enter a positive quantity."))
+                raise exceptions.UserError(_("Enter a positive quantity."))
 
             purchase = self.purchase_order_id
             if not purchase:

--- a/rma_sale/wizards/rma_order_line_make_sale_order.py
+++ b/rma_sale/wizards/rma_order_line_make_sale_order.py
@@ -122,7 +122,7 @@ class RmaLineMakeSaleOrder(models.TransientModel):
         for item in self.item_ids:
             line = item.line_id
             if item.product_qty <= 0.0:
-                raise exceptions.Warning(_("Enter a positive quantity."))
+                raise exceptions.UserError(_("Enter a positive quantity."))
 
             if self.sale_order_id:
                 sale = self.sale_order_id


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b4efbe95-5ae6-4098-9274-5b1def1a6897)

instead of:

![image](https://github.com/user-attachments/assets/e0916127-da21-4cdf-a913-8792a3724f78)

