### PR TITLE
[16.0][FIX] rma_puchase: write-off differences in price between rma line and vendor refund for standard price.

### DIFF
--- a/rma_purchase/models/account_move.py
+++ b/rma_purchase/models/account_move.py
@@ -110,11 +110,6 @@ class AccountMove(models.Model):
                     price_unit = line.product_id.uom_id._compute_price(
                         line.product_id.standard_price, line.product_uom_id
                     )
-                    price_unit = (
-                        -price_unit
-                        if line.move_id.move_type == "in_refund"
-                        else price_unit
-                    )
                     valuation_date = (
                         valuation_stock_moves
                         and max(valuation_stock_moves.mapped("date"))

--- a/rma_purchase/tests/test_rma_stock_account_purchase.py
+++ b/rma_purchase/tests/test_rma_stock_account_purchase.py
@@ -220,3 +220,75 @@ class TestRmaStockAccountPurchase(TestRmaStockAccount):
             ]
         )
         self.assertEqual(sum(price_diff_amls.mapped("balance")), -100)
+
+    def test_04_return_and_refund_diff_price_standard(self):
+        """
+        Same than test_03 but for standard cost
+        """
+        # extra variable to pass pre-commit
+        account_pd = self.account_price_diff
+        self.product_fifo_1.categ_id.update(
+            {
+                "property_account_creditor_price_difference_categ": account_pd,
+                "property_cost_method": "standard",
+            }
+        )
+        self.product_fifo_1.standard_price = 100
+        po = self.po_model.create(
+            {
+                "partner_id": self.partner_id.id,
+            }
+        )
+        pol_1 = self.pol_model.create(
+            {
+                "name": self.product_fifo_1.name,
+                "order_id": po.id,
+                "product_id": self.product_fifo_1.id,
+                "product_qty": 10.0,
+                "product_uom": self.product_fifo_1.uom_id.id,
+                "price_unit": 100.0,
+                "date_planned": Datetime.now(),
+            }
+        )
+        po.button_confirm()
+        self._do_picking(po.picking_ids)
+        supplier_view = self.env.ref("rma_purchase.view_rma_line_form")
+        rma_line = Form(
+            self.rma_line.with_context(supplier=1).with_user(self.rma_basic_user),
+            view=supplier_view.id,
+        )
+        rma_line.partner_id = po.partner_id
+        rma_line.purchase_order_line_id = pol_1
+        rma_line.operation_id = self.rma_operation_supplier_refund
+        rma_line = rma_line.save()
+        rma_line.action_rma_to_approve()
+        self._deliver_rma(rma_line)
+        with Form(
+            self.env["account.move"].with_context(default_move_type="in_refund")
+        ) as bill_form:
+            bill_form.partner_id = rma_line.partner_id
+            bill_form.invoice_date = Date.today()
+            bill_form.add_rma_line_id = rma_line
+        bill = bill_form.save()
+        bill_form = Form(bill)
+        with bill_form.invoice_line_ids.edit(0) as line_form:
+            line_form.price_unit = 110
+        bill = bill_form.save()
+        bill.action_post()
+        self.assertEqual(len(bill.invoice_line_ids), 1)
+        self.assertEqual(bill.invoice_line_ids.rma_line_id, rma_line)
+        grni_amls = self.env["account.move.line"].search(
+            [
+                ("account_id", "=", self.account_grni.id),
+                ("rma_line_id", "=", rma_line.id),
+            ]
+        )
+        self.assertEqual(sum(grni_amls.mapped("balance")), 0.0)
+        # self.assertTrue(all(grni_amls.mapped("reconciled")))
+        price_diff_amls = self.env["account.move.line"].search(
+            [
+                ("account_id", "=", self.account_price_diff.id),
+                ("rma_line_id", "=", rma_line.id),
+            ]
+        )
+        self.assertEqual(sum(price_diff_amls.mapped("balance")), -100)


### PR DESCRIPTION
The FWD port of: https://github.com/ForgeFlow/stock-rma/pull/403 was not entirely correct for standard price

also added a test.