### PR TITLE
[16.0][FIX] rma: RMA group view inbound vs outbound group

### DIFF
--- a/rma/views/rma_order_view.xml
+++ b/rma/views/rma_order_view.xml
@@ -172,11 +172,15 @@
                     </group>
                 </group>
                 <group>
-                    <group name="inbound_route" string="Inbound">
+                    <group name="operation" string="Default Operation">">
                         <field
                                 name="operation_default_id"
                                 domain="[('type','=','customer')]"
                             />
+                    </group>
+                </group>
+                <group>
+                    <group name="inbound_route" string="Inbound">
                         <field
                                 name="in_warehouse_id"
                                 attrs="{'readonly':[('state', '!=', 'draft')]}"
@@ -192,11 +196,6 @@
                             />
                         <field
                                 name="location_id"
-                                attrs="{'readonly':[('state', '!=', 'draft')]}"
-                            />
-                        <field
-                                name="out_route_id"
-                                invisible="1"
                                 attrs="{'readonly':[('state', '!=', 'draft')]}"
                             />
                         <field
@@ -302,6 +301,15 @@
             </field>
             <group name="inbound_route" position="after">
                 <group name="outbound_route" string="Outbound">
+                    <field
+                        name="out_route_id"
+                        invisible="1"
+                        attrs="{'readonly':[('state', '!=', 'draft')]}"
+                    />
+                    <field
+                        name="location_supplier_id"
+                        attrs="{'readonly':[('state', '!=', 'draft')]}"
+                    />
                     <field
                         name="supplier_to_customer"
                         attrs="{'readonly':[('state', '!=', 'draft')]}"


### PR DESCRIPTION
- The out route is in inbound --> moved to outbound
- Add the default supplier location in outbound
- The default operation has own group in the rma line form view. Here we do the same


Before:
<img width="1512" height="228" alt="rma_group_bad" src="https://github.com/user-attachments/assets/221af7e5-40bb-4386-9b96-e9ace7b43897" />

After:
<img width="1344" height="311" alt="rma_group_good" src="https://github.com/user-attachments/assets/db997288-7024-4832-a048-376d2a1fa1aa" />

 