### PR TITLE
[17.0][FIX] rma: RMA group view inbound vs outbound group

### DIFF
--- a/rma/views/rma_order_view.xml
+++ b/rma/views/rma_order_view.xml
@@ -163,24 +163,18 @@
                     </group>
                 </group>
                 <group>
-                    <group name="inbound_route" string="Inbound">
+                    <group name="operation" string="Default Operation">">
                         <field
                                 name="operation_default_id"
                                 domain="[('type','=','customer')]"
                             />
+                    </group>
+                </group>
+                <group name="route">
+                    <group name="inbound_route" string="Inbound">
                         <field name="in_warehouse_id" readonly="state != 'draft'" />
                         <field name="in_route_id" readonly="state != 'draft'" />
-                        <field
-                                name="out_warehouse_id"
-                                invisible="1"
-                                readonly="state != 'draft'"
-                            />
                         <field name="location_id" readonly="state != 'draft'" />
-                        <field
-                                name="out_route_id"
-                                invisible="1"
-                                readonly="state != 'draft'"
-                            />
                         <field
                                 name="customer_to_supplier"
                                 readonly="state != 'draft'"
@@ -302,6 +296,13 @@
             </field>
             <group name="inbound_route" position="after">
                 <group name="outbound_route" string="Outbound">
+                    <field
+                        name="out_warehouse_id"
+                        invisible="1"
+                        readonly="state != 'draft'"
+                    />
+                    <field name="out_route_id" readonly="state != 'draft'" />
+                    <field name="location_supplier_id" readonly="state != 'draft'" />
                     <field name="supplier_to_customer" readonly="state != 'draft'" />
                     <field
                         name="customer_address_id"


### PR DESCRIPTION
FW Port of https://github.com/ForgeFlow/stock-rma/pull/678

Now inbound fields are correctly separate and the operation  has its own group:
<img width="1175" height="336" alt="image" src="https://github.com/user-attachments/assets/8123d266-beb9-4c02-9502-737edb0c8f4d" />
