### PR TITLE
[18.0][FIX] rma: RMA group view inbound vs outbound group

### DIFF
--- a/rma/README.rst
+++ b/rma/README.rst
@@ -57,21 +57,21 @@ Go to Settings > Users and assign the appropiate permissions to users.
 Different security groups grant distinct levels of access to the RMA
 features.
 
-- Users in group "RMA Customer User" or "RMA Supplier User" can access
-  to, create and process RMA's associated to customers or suppliers
-  respectively.
-- Users in group "RMA Manager" can access to, create, approve and
-  process RMA's associated to both customers and suppliers.
+-  Users in group "RMA Customer User" or "RMA Supplier User" can access
+   to, create and process RMA's associated to customers or suppliers
+   respectively.
+-  Users in group "RMA Manager" can access to, create, approve and
+   process RMA's associated to both customers and suppliers.
 
 RMA Approval Policy
 -------------------
 
 There are two RMA approval policies in product catogories:
 
-- One step: Always auto-approve RMAs that only contain products within
-  categories with this policy.
-- Two steps: A RMA order containing a product within a category with
-  this policy will request the RMA manager approval.
+-  One step: Always auto-approve RMAs that only contain products within
+   categories with this policy.
+-  Two steps: A RMA order containing a product within a category with
+   this policy will request the RMA manager approval.
 
 In order to change the approval policy of a product category follow the
 next steps:
@@ -115,12 +115,12 @@ Create an RMA:
 Known issues / Roadmap
 ======================
 
-- Picking operations report in customer RMA dropshipping case is showing
-  "Vendor Address" while it should be "Customer Address".
-- Dropshipping always counted as a delivery on the smart buttons.
-- Uninstall hook.
-- Constraints instead of required fields on rma.order.line.
-- Rename type field on rma.order and rma.order.line
+-  Picking operations report in customer RMA dropshipping case is
+   showing "Vendor Address" while it should be "Customer Address".
+-  Dropshipping always counted as a delivery on the smart buttons.
+-  Uninstall hook.
+-  Constraints instead of required fields on rma.order.line.
+-  Rename type field on rma.order and rma.order.line
 
 Bug Tracker
 ===========
@@ -143,14 +143,14 @@ Authors
 Contributors
 ------------
 
-- Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
-- Aaron Henriquez <ahenriquez@forgeflow.com>
-- Lois Rilo <lois.rilo@forgeflow.com>
-- Bhavesh Odedra <bodedra@opensourceintegrators.com>
-- Akim Juillerat <akim.juillerat@camptocamp.com>
-- Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
-- Chafique Delli <chafique.delli@akretion.com>
-- Héctor Villarreal <hector.villarreal@forgeflow.com>
+-  Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
+-  Aaron Henriquez <ahenriquez@forgeflow.com>
+-  Lois Rilo <lois.rilo@forgeflow.com>
+-  Bhavesh Odedra <bodedra@opensourceintegrators.com>
+-  Akim Juillerat <akim.juillerat@camptocamp.com>
+-  Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+-  Chafique Delli <chafique.delli@akretion.com>
+-  Héctor Villarreal <hector.villarreal@forgeflow.com>
 
 Maintainers
 -----------

--- a/rma/static/description/index.html
+++ b/rma/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -472,8 +473,8 @@ required.</li>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-6">Known issues / Roadmap</a></h1>
 <ul class="simple">
-<li>Picking operations report in customer RMA dropshipping case is showing
-“Vendor Address” while it should be “Customer Address”.</li>
+<li>Picking operations report in customer RMA dropshipping case is
+showing “Vendor Address” while it should be “Customer Address”.</li>
 <li>Dropshipping always counted as a delivery on the smart buttons.</li>
 <li>Uninstall hook.</li>
 <li>Constraints instead of required fields on rma.order.line.</li>

--- a/rma/views/rma_order_view.xml
+++ b/rma/views/rma_order_view.xml
@@ -202,11 +202,15 @@
                         </group>
                     </group>
                     <group>
-                        <group name="inbound_route" string="Inbound">
+                        <group name="operation" string="Default Operation">">
                             <field
-                                name="operation_default_id"
-                                domain="[('type','=','customer')]"
-                            />
+                            name="operation_default_id"
+                            domain="[('type','=','customer')]"
+                        />
+                        </group>
+                    </group>
+                    <group name="route">
+                        <group name="inbound_route" string="Inbound">
                             <field name="in_warehouse_id" readonly="state != 'draft'" />
                             <field name="in_route_id" readonly="state != 'draft'" />
                             <field
@@ -362,6 +366,13 @@
             </field>
             <group name="inbound_route" position="after">
                 <group name="outbound_route" string="Outbound">
+                    <field
+                        name="out_warehouse_id"
+                        invisible="1"
+                        readonly="state != 'draft'"
+                    />
+                    <field name="out_route_id" readonly="state != 'draft'" />
+                    <field name="location_supplier_id" readonly="state != 'draft'" />
                     <field name="supplier_to_customer" readonly="state != 'draft'" />
                     <field
                         name="customer_address_id"


### PR DESCRIPTION
FW Port of https://github.com/ForgeFlow/stock-rma/pull/678

Now inbound fields are correctly separate and the operation has its own group:
<img width="1019" height="377" alt="image" src="https://github.com/user-attachments/assets/8437650a-bfce-421f-b474-0a331f0ad903" />
