### PR TITLE
[18.0][FIX] rma_repair

### DIFF
--- a/rma_repair/wizards/rma_order_line_make_repair.py
+++ b/rma_repair/wizards/rma_order_line_make_repair.py
@@ -68,7 +68,7 @@ class RmaLineMakeRepair(models.TransientModel):
         return {
             "domain": [("id", "in", res)],
             "name": self.env._("Repairs"),
-            "view_mode": "tree,form",
+            "view_mode": "list,form",
             "res_model": "repair.order",
             "view_id": False,
             "context": False,


### PR DESCRIPTION
When we want to create a repair order from an RMA line, in the wizard, we get this error:
View types not defined tree found in act_window action undefined

@JasminSForgeFlow , @LoisRForgeFlow 