### PR TITLE
[18.0][IMP] rma_repair

### DIFF
--- a/rma_repair/models/repair.py
+++ b/rma_repair/models/repair.py
@@ -10,6 +10,7 @@ class RepairOrder(models.Model):
     rma_line_id = fields.Many2one(
         comodel_name="rma.order.line", string="RMA", ondelete="restrict"
     )
-    under_warranty = fields.Boolean(
+    rma_under_warranty = fields.Boolean(
+        string="Under Warranty",
         related="rma_line_id.under_warranty",
     )

--- a/rma_repair/models/repair.py
+++ b/rma_repair/models/repair.py
@@ -10,7 +10,6 @@ class RepairOrder(models.Model):
     rma_line_id = fields.Many2one(
         comodel_name="rma.order.line", string="RMA", ondelete="restrict"
     )
-    rma_under_warranty = fields.Boolean(
-        string="Under Warranty",
+    under_warranty = fields.Boolean(
         related="rma_line_id.under_warranty",
     )

--- a/rma_repair/views/repair_view.xml
+++ b/rma_repair/views/repair_view.xml
@@ -7,11 +7,7 @@
         <field name="arch" type="xml">
             <field name="tag_ids" position="after">
                 <field name="rma_line_id" />
-                <field name="rma_under_warranty" invisible="not rma_line_id" />
             </field>
-            <xpath expr="//field[@name='under_warranty']" position="attributes">
-                <attribute name="invisible">rma_line_id</attribute>
-            </xpath>
         </field>
     </record>
 </odoo>

--- a/rma_repair/views/repair_view.xml
+++ b/rma_repair/views/repair_view.xml
@@ -7,8 +7,11 @@
         <field name="arch" type="xml">
             <field name="tag_ids" position="after">
                 <field name="rma_line_id" />
-                <field name="under_warranty" />
+                <field name="rma_under_warranty" invisible="not rma_line_id" />
             </field>
+            <xpath expr="//field[@name='under_warranty']" position="attributes">
+                <attribute name="invisible">rma_line_id</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
On the repair order, the basic field 'Under warranty' and the field 'Under warranty' linked to the RMA are confusing.
I think it's better to display only one of the two.

@JasminSForgeFlow , @LoisRForgeFlow