### PR TITLE
[16.0][FIX] Add ondelete=cascade to wizard item wiz_id fields

### DIFF
--- a/rma_account/wizards/rma_refund.py
+++ b/rma_account/wizards/rma_refund.py
@@ -218,7 +218,9 @@ class RmaRefundItem(models.TransientModel):
     _name = "rma.refund.item"
     _description = "RMA Lines to refund"
 
-    wiz_id = fields.Many2one(comodel_name="rma.refund", string="Wizard", required=True)
+    wiz_id = fields.Many2one(
+        comodel_name="rma.refund", string="Wizard", required=True, ondelete="cascade"
+    )
     line_id = fields.Many2one(
         "rma.order.line",
         string="RMA order Line",

--- a/rma_purchase/wizards/rma_order_line_make_purchase_order.py
+++ b/rma_purchase/wizards/rma_order_line_make_purchase_order.py
@@ -140,7 +140,9 @@ class RmaLineMakePurchaseOrderItem(models.TransientModel):
     _description = "RMA Line Make Purchase Order Item"
 
     wiz_id = fields.Many2one(
-        comodel_name="rma.order.line.make.purchase.order", string="Wizard"
+        comodel_name="rma.order.line.make.purchase.order",
+        string="Wizard",
+        ondelete="cascade",
     )
     line_id = fields.Many2one(comodel_name="rma.order.line", string="RMA Line")
     rma_id = fields.Many2one(

--- a/rma_put_away/wizards/rma_make_put_away.py
+++ b/rma_put_away/wizards/rma_make_put_away.py
@@ -124,7 +124,9 @@ class RmaMakePutAwayItem(models.TransientModel):
     _name = "rma_make_put_away_item.wizard"
     _description = "Items to Put Away"
 
-    wiz_id = fields.Many2one("rma_make_put_away.wizard", string="Wizard", required=True)
+    wiz_id = fields.Many2one(
+        "rma_make_put_away.wizard", string="Wizard", required=True, ondelete="cascade"
+    )
     line_id = fields.Many2one(
         "rma.order.line", string="RMA order Line", ondelete="cascade"
     )

--- a/rma_sale/wizards/rma_order_line_make_sale_order.py
+++ b/rma_sale/wizards/rma_order_line_make_sale_order.py
@@ -147,7 +147,9 @@ class RmaLineMakeSaleOrderItem(models.TransientModel):
     _description = "RMA Line Make Sale Order Item"
 
     wiz_id = fields.Many2one(
-        comodel_name="rma.order.line.make.sale.order", string="Wizard"
+        comodel_name="rma.order.line.make.sale.order",
+        string="Wizard",
+        ondelete="cascade",
     )
     line_id = fields.Many2one(
         comodel_name="rma.order.line", string="RMA Line", compute="_compute_line_id"

--- a/rma_scrap/wizards/rma_make_scrap.py
+++ b/rma_scrap/wizards/rma_make_scrap.py
@@ -90,7 +90,9 @@ class RmaMakeScrapItem(models.TransientModel):
     _name = "rma_make_scrap_item.wizard"
     _description = "Items to Scrap"
 
-    wiz_id = fields.Many2one("rma_make_scrap.wizard", string="Wizard", required=True)
+    wiz_id = fields.Many2one(
+        "rma_make_scrap.wizard", string="Wizard", required=True, ondelete="cascade"
+    )
     line_id = fields.Many2one(
         "rma.order.line", string="RMA order Line", ondelete="cascade", required=True
     )


### PR DESCRIPTION
## Summary

Fix `ForeignKeyViolation` errors when `ir.autovacuum` cleans up transient wizard records.

Without `ondelete="cascade"` on the `wiz_id` field, deleting the parent wizard leaves orphan child items that still reference it, causing FK constraint violations:

```
ForeignKeyViolation: UPDATE or DELETE on table "rma_refund" violates foreign key constraint
"rma_refund_item_wiz_id_fkey" on table "rma_refund_item"
DETAIL: Key (id)=(123) is still referenced from table "rma_refund_item".
```

This follows the pattern from PR #489 (commit 03ecdff7) which fixed the same issue for `rma_make_picking_wizard_item`.

## Affected wizards

| Module | TransientModel |
|--------|----------------|
| rma_account | `rma.refund.item` |
| rma_purchase | `rma.order.line.make.purchase.order.item` |
| rma_sale | `rma.order.line.make.sale.order.item` |
| rma_put_away | `rma_make_put_away_item.wizard` |
| rma_scrap | `rma_make_scrap_item.wizard` |

## Test plan

- [x] Pre-commit hooks pass
- [ ] Wait for ir.autovacuum cron to run and verify no FK errors in logs