### PR TITLE
[18.0][FIX] rma_purchase: fix missing arguments in call to super

### DIFF
--- a/rma_purchase/models/purchase_order.py
+++ b/rma_purchase/models/purchase_order.py
@@ -10,7 +10,7 @@ class PurchaseOrder(models.Model):
     @api.model
     def new(self, vals, origin=None, ref=None):
         """Allows to propose a line based on the RMA information."""
-        res = super().new(vals)
+        res = super().new(vals, origin=origin, ref=ref)
         rma_line_id = self.env.context.get("rma_line_id")
         if rma_line_id:
             rma_line = self.env["rma.order.line"].browse(rma_line_id)


### PR DESCRIPTION
# Issue

On purchase orders with a non-default currency, currency conversion is wrong on new purchase order lines.

# How to reproduce

Create a purchase order and set the currency to a non-default currency. Be sure to save the purchase order. Then click Add Product. You can see that the currency on the new line is already wrong, and is not taken from the line's purchase order.

<img width="1661" height="633" alt="image" src="https://github.com/user-attachments/assets/364f7d83-ffe2-479b-b9f3-2968f5750182" />

# Actual result

When a price is derived from a product supplierinfo (which has a specific currency) the rate conversion is not applied as expected.



Since 14.0! https://github.com/ForgeFlow/stock-rma/pull/153/changes/9de5abcf25789450e4bf017e896ce27964ec67d4